### PR TITLE
Http redirect added to one time payment.

### DIFF
--- a/app/controllers/one_time_payments_controller.rb
+++ b/app/controllers/one_time_payments_controller.rb
@@ -19,7 +19,7 @@ class OneTimePaymentsController < ApplicationController
         source: token,
         description: params[:payments][:description])
 
-      redirect_to confirmation_path
+      redirect_to confirmation_url(host: ENV['APPLICATION_HOST'], protocol: "http")
     rescue Stripe::CardError => e
       flash[:danger] = e.message
       render :new


### PR DESCRIPTION
To do: set prod's application host environment variable

heroku config:set APPLICATION_HOST= app.toptutoring.com