### PR TITLE
Hours input added on tutor payment form.

### DIFF
--- a/app/assets/javascripts/dwolla_transfer.js
+++ b/app/assets/javascripts/dwolla_transfer.js
@@ -1,0 +1,19 @@
+jQuery(function($) {
+  $('#payment_amount').on('keyup', function(e) {
+    if ($('#payment_amount').val() != '') {
+      tutor_id = $('#payment_payee_id').val();
+      rate = $('#' + tutor_id + '_tutor_hourly_rate').val();
+      var hours = parseFloat($('#payment_amount').val()) / parseFloat(rate);
+      $('#tutor_hours').val(hours);
+    }
+  });
+
+  $('#tutor_hours').on('keyup', function(e) {
+    if ($('#tutor_hours').val() != '' && $('#tutor_hours').val() >= 0) {
+      tutor_id = $('#payment_payee_id').val();
+      rate = $('#' + tutor_id + '_tutor_hourly_rate').val();
+      var total = parseFloat($('#tutor_hours').val()) * parseFloat(rate);
+      $('#payment_amount').val(total);
+    }
+  });
+});

--- a/app/views/admin/payments/new.html.erb
+++ b/app/views/admin/payments/new.html.erb
@@ -11,11 +11,21 @@
             <%= form.select :payee_id, options_from_collection_for_select(@tutors, :id, :name), {}, class: "form-control" %>
           </div>
 
+          <% @tutors.each do |tutor| %>
+            <input type="hidden" id="<%= tutor.id %>_tutor_hourly_rate" value="<%= tutor.tutor.hourly_rate %>"></input>
+          <% end %>
+
+          <div class="form-group">
+            <label for="hours">Hours</label>
+              <input type="number" class="form-control no-padding" id="tutor_hours" name="payments[hours]" min="0.5" max="9999" required step="0.5">
+            </input>
+          </div>
+
           <div class="form-group">
             <%= form.label :amount, "Amount:" %>
             <div class="input-group">
               <div class="input-group-addon">$</div>
-              <%= form.number_field :amount, class: "form-control no-padding", required: true, min: "1" %>
+              <%= form.number_field :amount, class: "form-control no-padding", id: "payment_amount", required: true, min: "1" %>
               <div class="input-group-addon">.00</div>
             </div>
           </div>


### PR DESCRIPTION
This PR adds an hours input field on tutoring payment form. The hours field populates the amount field base on tutor's hourly balance and vice versa.

![screencapture-toptutoring-staging-pr-50-herokuapp-admin-payments-new-1487278647535](https://cloud.githubusercontent.com/assets/17921522/23040932/e445a72e-f49b-11e6-9062-a7c2fef0767d.png)