### PR TITLE
One time payments path changed

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-
+  layout "authentication", only: [:payment]
   def admin_dashboard
     render "admin_dashboard", :layout => false
   end

--- a/app/controllers/users/clients_controller.rb
+++ b/app/controllers/users/clients_controller.rb
@@ -11,8 +11,8 @@ module Users
     def create
       @user = Clearance.configuration.user_model.new(signups_params)
       if @user.save
-        #UserNotifierMailer.send_signup_email(@user).deliver_now
-        #NewClientNotifierMailer.welcome(@user, User.admin_and_directors).deliver_now
+        UserNotifierMailer.send_signup_email(@user).deliver_now
+        NewClientNotifierMailer.welcome(@user, User.admin_and_directors).deliver_now
         sign_in(@user)
         redirect_to :root
       else

--- a/app/views/application/_authentication_header.html.erb
+++ b/app/views/application/_authentication_header.html.erb
@@ -26,6 +26,9 @@
                 <a class="page-link logo-dark" href="http://www.toptutoring.com/blog/">Blog</a>
               </li>
               <li>
+                <%= link_to "Sign in", sign_in_path, class: "page-link logo-dark" %>
+              </li>
+              <li>
                 <%= link_to "Sign up", new_users_client_path, class: "page-link logo-dark" %>
               </li>
             </ul>

--- a/app/views/one_time_payments/confirmation.html.erb
+++ b/app/views/one_time_payments/confirmation.html.erb
@@ -1,3 +1,4 @@
+</br></br></br>
 <div class="payment-container text-center">
   <h3 class="confirmation-title">Payment successfully completed!</h3>
 </div>

--- a/app/views/one_time_payments/new.html.erb
+++ b/app/views/one_time_payments/new.html.erb
@@ -1,3 +1,4 @@
+</br></br></br>
 <section>
 
     <div class="row">

--- a/app/views/pages/payment.html.erb
+++ b/app/views/pages/payment.html.erb
@@ -1,0 +1,20 @@
+</br>
+<div class="payment-container text-center">
+  <h5 class="confirmation-title">Thank you for trying to make a payment.  We have moved your payment page into your dashboard after you log in.</h5>
+</div>
+
+</br>
+<div class="payment-container text-center">
+  <h5 class="confirmation-title">
+    Please
+    <%= link_to "log in", sign_in_path %>.
+    If this is your first time logging in, you may need to <%= link_to "reset your password", reset_password_path %>.
+  </h5>
+</div>
+
+</br>
+<div class="payment-container text-center">
+  <h5 class="confirmation-title">
+    In the future, you can log in at any time with the 'Sign In' link at the top of the page.
+  </h5>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,10 @@ Rails.application.routes.draw do
   post "/passwords" => "passwords#create"
   get "/example_dashboard" => "pages#example_dashboard"
   get "/calendar" => "pages#calendar"
-  get "/payment" => "one_time_payments#new"
+  get "/one_time_payment" => "one_time_payments#new"
   post "/payments/one_time" => "one_time_payments#create"
   get "/confirmation" => "one_time_payments#confirmation"
+  get "payment" => "pages#payment"
 
   # Omniauth routes
   get "/auth/dwolla/callback", to: "auth_callbacks#create"
@@ -55,6 +56,9 @@ Rails.application.routes.draw do
 
   constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("client") } do
     get "/payment/new" => "payments#new"
+    get "/one_time_payment" => "one_time_payments#new"
+    post "/payments/one_time" => "one_time_payments#create"
+    get "/confirmation" => "one_time_payments#confirmation"
     resources :students, only: [:index, :new, :create]
   end
 


### PR DESCRIPTION
This pr moves the one time payment form from /payment to /one_time_payment and adds a message to the /payment page.

**Payment page message**


![screencapture-toptutoring-staging-pr-68-herokuapp-payment-1490183185990](https://cloud.githubusercontent.com/assets/17921522/24196397/536f1c1e-0f06-11e7-9d55-df9567edd1ff.png)


**Anonymous user one time payment page**


![screencapture-toptutoring-staging-pr-68-herokuapp-one_time_payment-1490183210267](https://cloud.githubusercontent.com/assets/17921522/24196399/56c7ee7c-0f06-11e7-9f01-5b6fcdd7f134.png)


**Anonymous user confirmation page**


![screencapture-toptutoring-staging-pr-68-herokuapp-confirmation-1490183282432](https://cloud.githubusercontent.com/assets/17921522/24196416/65507090-0f06-11e7-9322-5ca99c477a4a.png)


**Logged in user payment form**
![screencapture-toptutoring-staging-pr-68-herokuapp-one_time_payment-1490202188050](https://cloud.githubusercontent.com/assets/17921522/24210584/405310e6-0f32-11e7-864b-76b859f7cde5.png)


**Logged in user confirmation page**
![screencapture-toptutoring-staging-pr-68-herokuapp-confirmation-1490183259109](https://cloud.githubusercontent.com/assets/17921522/24196407/608599f0-0f06-11e7-9f99-e802eb5663c0.png)
