### PR TITLE
Remove card info from set up account form.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"
   gem "rb-readline"
-  gem "rspec-rails", "~> 3.5.0.beta4"
-  gem "vcr"
 end
 
 group :development, :staging do
@@ -68,6 +66,10 @@ group :test do
   gem "simplecov", require: false
   gem "timecop"
   gem "webmock"
+  gem 'fake_stripe'
+  gem 'sinatra', '~> 2.0.0.rc2', require: false
+  gem "vcr"
+  gem "rspec-rails", "~> 3.5.0.beta4"
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    fake_stripe (0.0.12)
+      capybara
+      sinatra
+      webmock
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.11.0.1)
@@ -152,6 +156,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.0)
     netrc (0.11.0)
     newrelic_rpm (3.15.2.317)
     nio4r (1.2.1)
@@ -185,7 +190,7 @@ GEM
     rack (2.0.1)
     rack-mini-profiler (0.10.1)
       rack (>= 1.2.0)
-    rack-protection (1.5.3)
+    rack-protection (2.0.0.rc2)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -269,6 +274,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sinatra (2.0.0.rc2)
+      mustermann (= 1.0.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0.rc2)
+      tilt (~> 2.0)
     skylight (1.0.1)
       activesupport (>= 3.0.0)
     slop (3.6.0)
@@ -342,6 +352,7 @@ DEPENDENCIES
   dotenv-rails
   dwolla_v2 (~> 1.0)
   factory_girl_rails
+  fake_stripe
   formulaic
   honeybadger
   intercom-rails
@@ -369,6 +380,7 @@ DEPENDENCIES
   sidekiq
   simple_form
   simplecov
+  sinatra (~> 2.0.0.rc2)
   skylight
   spring
   spring-commands-rspec

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -466,3 +466,15 @@ legend {
     color: #fff;
   }
 }
+
+.set-up-account {
+  margin-left: -10%;
+}
+
+.wizard > .content > .body {
+  padding-top: 0px;
+}
+
+.payment-section {
+  padding-top: 65px;
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class DashboardsController < ApplicationController
   before_action :require_login
+  before_action :build_student_for_client, only: [:client]
 
   def admin
     @assignments = Assignment.pending
@@ -11,5 +12,13 @@ class DashboardsController < ApplicationController
 
   def tutor
     @assignments = current_user.assignments
+  end
+
+  private
+
+  def build_student_for_client
+    if !current_user.is_student?
+      current_user.students.build
+    end
   end
 end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,6 +1,12 @@
 class PaymentsController < ApplicationController
   before_action :require_login
 
+  def new
+    if !current_user.is_customer?
+      redirect_to one_time_payment_path
+    end
+  end
+
   def index
     @payments = Payment.from_customer(current_user.customer_id)
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,10 +22,8 @@ class SessionsController < Clearance::SessionsController
   private
 
   def url_after_create
-    if current_user.disabled? && current_user.has_role?("client")
-      edit_user_path(current_user)
-    elsif current_user.has_role?("client")
-      payment_new_path
+    if current_user.has_role?("client") && current_user.enabled?
+      new_payment_path
     else
       dashboard_path
     end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -10,8 +10,10 @@ class StudentsController < ApplicationController
     @user = Clearance.configuration.user_model.new(student_params)
     @user.client_id = current_user.id
     if @user.save
-      @user.forgot_password!
-      SetStudentPasswordMailer.set_password(@user).deliver_now
+      if @user.email.present?
+        @user.forgot_password!
+        SetStudentPasswordMailer.set_password(@user).deliver_now
+      end
       Assignment.create(
         student_id: @user.id,
         subject: @user.student_info.subject)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,6 @@ class User < ActiveRecord::Base
   attr_encrypted :refresh_token, key: ENV.fetch("ENCRYPTOR_KEY")
 
   # Validation #
-  validates_uniqueness_of :email
   validates_presence_of :name
 
   # Scopes #
@@ -94,5 +93,10 @@ class User < ActiveRecord::Base
 
   def is_student?
     client_info&.tutoring_for == 0
+  end
+
+  # Overide clearance email validation
+  def email_optional?
+    client_id.present?
   end
 end

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -1,95 +1,97 @@
-<aside data-mcs-theme="minimal-dark" class="main-sidebar mCustomScrollbar">
-  <div class="media user">
-    <div class="media-left">
-      <div id="esp-user-profile" data-percent="66" style="height: 56px; width: 56px; line-height: 40px; padding: 8px;" class="easy-pie-chart"><i class="icon ion-ios-person avatar img-circle"></i></div>
+<% if current_user.enabled? %>
+  <aside data-mcs-theme="minimal-dark" class="main-sidebar mCustomScrollbar">
+    <div class="media user">
+      <div class="media-left">
+        <div id="esp-user-profile" data-percent="66" style="height: 56px; width: 56px; line-height: 40px; padding: 8px;" class="easy-pie-chart"><i class="icon ion-ios-person avatar img-circle"></i></div>
+      </div>
+      <div class="media-body media-middle">
+        <h4 class="media-heading fs-16"><%= current_user.name %></h4>
+        <% if current_user.has_role?("client") %>
+          <div class="dropdown">
+            <a id="dropdown-status" href="#" role="button" aria-haspopup="true" class="dropdown-toggle">
+              <%= client_balance(current_user) %>
+            </a>
+            <ul aria-labelledby="dropdown-status" class="dropdown-menu animated fadeInUp">
+            </ul>
+          </div>
+        <% elsif current_user.has_role?("tutor") %>
+          <div class="dropdown">
+            <a id="dropdown-status" href="#" role="button" aria-haspopup="true" class="dropdown-toggle">
+              <%= tutor_balance(current_user) %>
+            </a>
+            <ul aria-labelledby="dropdown-status" class="dropdown-menu animated fadeInUp">
+            </ul>
+          </div>
+        <% end %>
+      </div>
     </div>
-    <div class="media-body media-middle">
-      <h4 class="media-heading fs-16"><%= current_user.name %></h4>
+    <ul class="list-unstyled navigation mb-0">
       <% if current_user.has_role?("client") %>
-        <div class="dropdown">
-          <a id="dropdown-status" href="#" role="button" aria-haspopup="true" class="dropdown-toggle">
-            <%= client_balance(current_user) %>
-          </a>
-          <ul aria-labelledby="dropdown-status" class="dropdown-menu animated fadeInUp">
-          </ul>
-        </div>
-      <% elsif current_user.has_role?("tutor") %>
-        <div class="dropdown">
-          <a id="dropdown-status" href="#" role="button" aria-haspopup="true" class="dropdown-toggle">
-            <%= tutor_balance(current_user) %>
-          </a>
-          <ul aria-labelledby="dropdown-status" class="dropdown-menu animated fadeInUp">
-          </ul>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <ul class="list-unstyled navigation mb-0">
-    <% if current_user.has_role?("client") %>
-      <%= render "application/menu_links/client" %>
-    <% elsif current_user.has_role?("admin") || current_user.has_role?("director") %>
-    <li class="panel"><a href="/dashboard"><i class="ion-ios-home-outline bg-purple"></i><span class="sidebar-title">Dashboard</span></a></li>
-    <li class="panel"><a href="/admin/payments"><i class="ion-card bg-success"></i><span class="sidebar-title">Payments</span></a></li>
-    <li class="panel">
-      <%= link_to assignments_path do %>
-        <i class="icon ion-ios-contact bg-primary"></i>
-        <span class="sidebar-title">Assignments</span>
-      <% end %>
-    </li>
-    <li class="panel">
-      <%= link_to admin_tutors_path do %>
-        <i class="icon ion-ios-contact bg-purple"></i>
-        <span class="sidebar-title">Tutors</span>
-      <% end %>
-    </li>
-    <% elsif current_user.has_role?("tutor") %>
+        <%= render "application/menu_links/client" %>
+      <% elsif current_user.has_role?("admin") || current_user.has_role?("director") %>
       <li class="panel"><a href="/dashboard"><i class="ion-ios-home-outline bg-purple"></i><span class="sidebar-title">Dashboard</span></a></li>
-    <% end %>
-    <% if current_user.has_role?("admin") %>
+      <li class="panel"><a href="/admin/payments"><i class="ion-card bg-success"></i><span class="sidebar-title">Payments</span></a></li>
       <li class="panel">
-        <%= link_to admin_users_path do %>
-          <i class="icon ion-ios-contact bg-success"></i>
-          <span class="sidebar-title">Students</span>
+        <%= link_to assignments_path do %>
+          <i class="icon ion-ios-contact bg-primary"></i>
+          <span class="sidebar-title">Assignments</span>
         <% end %>
       </li>
       <li class="panel">
-        <%= link_to admin_invoices_path do %>
-          <i class="icon ion-clipboard bg-primary"></i>
-          <span class="sidebar-title">Invoices</span>
+        <%= link_to admin_tutors_path do %>
+          <i class="icon ion-ios-contact bg-purple"></i>
+          <span class="sidebar-title">Tutors</span>
         <% end %>
       </li>
-      <li class="panel">
-        <%= link_to admin_emails_path do %>
-          <i class="icon ion-ios-email-outline bg-danger"></i>
-          <span class="sidebar-title">Emails</span>
-        <% end %>
-      </li>
-      <li class="panel">
-        <%= link_to new_admin_funding_source_path do %>
-          <i class="icon ion-card bg-primary"></i>
-          <span class="sidebar-title">Funding Source</span>
-        <% end %>
-      </li>
-    <% end %>
-    <% if current_user.has_role?("tutor") %>
-      <li class="panel">
-        <%= link_to tutors_students_path do %>
-          <i class="icon ion-ios-contact bg-success"></i>
-          <span class="sidebar-title">Students</span>
-        <% end %>
-      </li>
-      <li class="panel">
-        <%= link_to tutors_invoices_path do %>
-          <i class="icon ion-clipboard bg-primary"></i>
-          <span class="sidebar-title">Invoices</span>
-        <% end %>
-      </li>
-      <li class="panel">
-        <%= link_to tutors_emails_path do %>
-          <i class="icon ion-ios-email-outline bg-danger"></i>
-          <span class="sidebar-title">Emails</span>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
-</aside>
+      <% elsif current_user.has_role?("tutor") %>
+        <li class="panel"><a href="/dashboard"><i class="ion-ios-home-outline bg-purple"></i><span class="sidebar-title">Dashboard</span></a></li>
+      <% end %>
+      <% if current_user.has_role?("admin") %>
+        <li class="panel">
+          <%= link_to admin_users_path do %>
+            <i class="icon ion-ios-contact bg-success"></i>
+            <span class="sidebar-title">Students</span>
+          <% end %>
+        </li>
+        <li class="panel">
+          <%= link_to admin_invoices_path do %>
+            <i class="icon ion-clipboard bg-primary"></i>
+            <span class="sidebar-title">Invoices</span>
+          <% end %>
+        </li>
+        <li class="panel">
+          <%= link_to admin_emails_path do %>
+            <i class="icon ion-ios-email-outline bg-danger"></i>
+            <span class="sidebar-title">Emails</span>
+          <% end %>
+        </li>
+        <li class="panel">
+          <%= link_to new_admin_funding_source_path do %>
+            <i class="icon ion-card bg-primary"></i>
+            <span class="sidebar-title">Funding Source</span>
+          <% end %>
+        </li>
+      <% end %>
+      <% if current_user.has_role?("tutor") %>
+        <li class="panel">
+          <%= link_to tutors_students_path do %>
+            <i class="icon ion-ios-contact bg-success"></i>
+            <span class="sidebar-title">Students</span>
+          <% end %>
+        </li>
+        <li class="panel">
+          <%= link_to tutors_invoices_path do %>
+            <i class="icon ion-clipboard bg-primary"></i>
+            <span class="sidebar-title">Invoices</span>
+          <% end %>
+        </li>
+        <li class="panel">
+          <%= link_to tutors_emails_path do %>
+            <i class="icon ion-ios-email-outline bg-danger"></i>
+            <span class="sidebar-title">Emails</span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </aside>
+<% end %>

--- a/app/views/dashboards/_new_user_message.html.erb
+++ b/app/views/dashboards/_new_user_message.html.erb
@@ -1,0 +1,3 @@
+<div class="col-md-12 set-up-account">
+  <%= render "users/set_up_account" %>
+</div>

--- a/app/views/dashboards/_pending_assignment_message.html.erb
+++ b/app/views/dashboards/_pending_assignment_message.html.erb
@@ -1,0 +1,7 @@
+<div class="col-md-8">
+  <div class="widget">
+    <div class="widget-heading">
+      We have received your information and we are in the process of finding the best tutor for you!
+    </div>
+  </div>
+</div>

--- a/app/views/dashboards/_student_pending_assignment_message.html.erb
+++ b/app/views/dashboards/_student_pending_assignment_message.html.erb
@@ -1,0 +1,7 @@
+<div class="col-md-8">
+  <div class="widget">
+    <div class="widget-heading">
+      We have received your information and we are in the process of finding the best tutor for you!
+    </div>
+  </div>
+</div>

--- a/app/views/dashboards/client.html.erb
+++ b/app/views/dashboards/client.html.erb
@@ -1,0 +1,12 @@
+<%= render "menu" %>
+<% unless current_user.enabled? %>
+  <%= render "new_user_message" %>
+<% end %>
+<% if current_user.enabled? %>
+  <% if !current_user.is_student? && current_user.students.first.assignment&.pending? %>
+    <%= render "student_pending_assignment_message" %>
+  <% end %>
+  <% if current_user.is_student? && current_user.assignment&.pending? %>
+    <%= render "pending_assignment_message" %>
+  <% end %>
+<% end %>

--- a/app/views/one_time_payments/confirmation.html.erb
+++ b/app/views/one_time_payments/confirmation.html.erb
@@ -1,4 +1,4 @@
 </br></br></br>
 <div class="payment-container text-center">
-  <h3 class="confirmation-title">Payment successfully completed!</h3>
+  <h3 class="confirmation-title">Payment successfully made!</h3>
 </div>

--- a/app/views/one_time_payments/new.html.erb
+++ b/app/views/one_time_payments/new.html.erb
@@ -1,5 +1,4 @@
-</br></br></br>
-<section>
+<section class="payment-section col-md-offset-1">
 
     <div class="row">
       <legend class="col-sm-6 col-sm-offset-4"><i class="glyphicon glyphicon-lock color-grey"></i> Secure Credit Card</legend>
@@ -24,7 +23,7 @@
         <div class="col-sm-2"></div>
         <label for="amount" class="col-sm-2 control-label">Amount</label>
         <div class="col-sm-3">
-          <input type="number" class="form-control col-sm-3 input-sm" name="payments[amount]" min="0" max="999999" required>
+          <input type="number" class="form-control col-sm-3 input-sm" name="payments[amount]" min="0" id="amount" max="999999" required>
           </input>
         </div>
       </div>
@@ -33,7 +32,7 @@
         <div class="col-sm-2"></div>
         <label for="description" class="col-sm-2 control-label">Description</label>
         <div class="col-sm-3">
-          <input type="text" class="form-control col-sm-3 input-sm"  name="payments[description]">
+          <input type="text" class="form-control col-sm-3 input-sm"  name="payments[description]" id="description">
           </input>
         </div>
       </div>
@@ -42,7 +41,7 @@
         <div class="col-sm-2"></div>
         <label for="card-holder-name" class="col-sm-2 control-label">Card Holder's Name</label>
         <div class="col-sm-3">
-          <input type="text" class="form-control col-sm-3 input-sm"  data-stripe="name" title="This is the name as written on your credit card.">
+          <input type="text" class="form-control col-sm-3 input-sm"  data-stripe="name" title="This is the name as written on your credit card." id="name">
           </input>
         </div>
       </div>
@@ -51,7 +50,7 @@
         <div class="col-sm-2"></div>
       <label for="credit-card-number" class="col-sm-2 control-label">Credit Card</label>
         <div class="col-sm-3">
-          <input type="text" class="form-control col-sm-3 input-sm"  data-stripe="number" title="Fill in your credit card number." maxlength="19" required>
+          <input type="text" class="form-control col-sm-3 input-sm"  data-stripe="number" title="Fill in your credit card number." maxlength="19" required id="credit-card">
           </input>
         </div>
         <img src="/img/credit-card-icons.png" class="img-responsive col-sm-2"></img>
@@ -98,6 +97,15 @@
       </div>
     </fieldset>
 
+    <% if current_user %>
+      <div class="form-group">
+        <div class="col-sm-offset-4">
+          <%= check_box_tag 'save_payment_info'  %>
+          <label>Save card information</label>
+        </div>
+      </div>
+    <% end %>
+
     <div class="form-group">
       <div class="col-xs-3 col-xs-offset-4">
         <input type="submit" value="Pay" class="btn btn-block payment_submit">
@@ -108,5 +116,4 @@
 
   <% end %>
 </section>
-
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+<%= javascript_include_tag "#{STRIPE_JS_HOST}/v2/" %>

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -12,11 +12,7 @@
             </div>
 
             <div class="form-group">
-              <%= f.email_field :email, class:"form-control", required: true, placeholder: "Email" %>
-            </div>
-
-            <div class="form-group">
-              <%= f.text_field number_to_phone(:phone_number), class:"form-control", placeholder: "Phone Number" %>
+              <%= f.email_field :email, class:"form-control", placeholder: "Email" %>
             </div>
 
             <%= f.fields_for :student_info do |student_field| %>

--- a/app/views/users/_set_up_account.html.erb
+++ b/app/views/users/_set_up_account.html.erb
@@ -1,9 +1,14 @@
   <div class="widget">
     <div class="widget-heading">
-      <h3 class="widget-title"></h3>
+      Thanks for using Top Tutoring. We provide excellent online tutoring
+      to people all over the world.
+    </br></br>
+      <p>
+        Please take a second to complete your account and get full access to our application.
+      </p>
     </div>
     <div class="widget-body">
-      <%= form_for(current_user, url: user_path(current_user), html: { method: :put, class: "payment-form", id: "form-vertical" }) do |f| %>
+      <%= form_for(current_user, url: user_path(current_user), html: { method: :put, id: "form-vertical" }) do |f| %>
         <h3>Acount Infomation</h3>
         <fieldset>
           <div class="row">
@@ -30,76 +35,11 @@
           </div>
         </fieldset>
         <% if current_user.is_student? %>
-          <%= render "client_fields", f: f %>
+          <%= render "users/client_fields", f: f %>
         <% else %>
-          <%= render "student_fields", f: f %>
+          <%= render "users/student_fields", f: f %>
         <% end %>
-        <h3>Payment Information</h3>
-        <fieldset class="credit-card">
-          <legend><i class="glyphicon glyphicon-lock color-grey"></i> Secure Credit Card Form</legend>
-          <div class="row">
-            <div class="col-md-6 col-md-offset-3">
-              <div class="form-group text-center">
-                <span class="payment-errors alert-danger col-sm-7"></span>
-              </div>
-            </div>
-          </div>
-          <p>Note: All fields are required.</p>
-          <p>This page is protected through secure SSL encrypted payment.</p>
-          <div class="row">
-            <div class="col-md-6">
-              <div class="form-group">
-                <label for="card-holder-name">Card Holder's Name</label>
-                <input type="text" class="form-control" id="card_holder"  data-stripe="name" title="This is the name as written on your credit card." required>
-                </input>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="form-group">
-                <label for="credit-card-number">Credit Card</label>
-                <input type="text" class="form-control"  id="credit_card" data-stripe="number" title="Fill in your credit card number." required>
-                </input>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <label for="exp">Expiration</label>
-              <div class="form-group select-option">
-                <div class="controls">
-                  <i class="ion-chevron-down"></i>
-                  <%= select_month(Date.today, {add_month_numbers: true}, name: nil, data: {stripe: "exp-month"}, required: true) %>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <label for="exp"></label>
-              <div class="form-group select-option">
-                <div class="controls">
-                  <i class="ion-chevron-down"></i>
-                  <%= select_year(Date.today.year, {start_year: Date.today.year, end_year: Date.today.year + 4}, name: nil, data: {stripe: "exp-year"}, required: true) %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group">
-                <div class="col-md-3 col-cvv-fixed-width left">
-                  <label for="cvv-code" class="control-label">CVV</label>
-                  <input type="text" class="form-control input-sm" id="cvc"  data-stripe="cvc" size="4" required></input>
-                </div>
-              </div>
-            </br>
-              <a id="cvv" class="col-md-3" data-content="<strong>Visa®, Mastercard®, and Discover® cardholders:</strong><p>Turn your card over and look at the signature box. You should see either the entire 16-digit credit card number or
-                just the last four digits followed by a special 3-digit code. This 3-digit code is your CVV number / Card Security Code.</p><strong> American Express® cardholders:</strong><p>Look for the 4-digit code printed on the front of your card just above and to the right of your main credit card number. This 4-digit code is your Card Identification Number (CID). The CID is the four-digit code printed just above the Account Number.</p>" data-placement="right" data-toggle="popover" class="btn" data-original-title="Card Verification Number" data-html="true" style="font-size:11px">What is my CVV code?</a>
-            </div>
-          </div>
-          <%= hidden_field_tag :token %>
-        </fieldset>
-        <%= hidden_field_tag :stripe_publishable_key, ENV['STRIPE_PUBLISHABLE_KEY'] %>
         <%= f.submit "", class:"hidden-submit" %>
       <% end %>
     </div>
   </div>
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>

--- a/app/views/users/_student_fields.html.erb
+++ b/app/views/users/_student_fields.html.erb
@@ -11,15 +11,7 @@
       <div class="col-md-6">
         <div class="form-group">
           <%= student_field.label :student_email %>
-          <%= student_field.email_field :email, class:"form-control", required: true %>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= student_field.label :student_phone_number %>
-          <%= student_field.text_field number_to_phone(:phone_number), value: number_to_phone(current_user.phone_number), class:"form-control" %>
+          <%= student_field.email_field :email, class:"form-control" %>
         </div>
       </div>
     </div>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,3 @@
+unless defined? STRIPE_JS_HOST
+  STRIPE_JS_HOST = 'https://js.stripe.com'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     post "/payments/one_time" => "one_time_payments#create"
     get "/confirmation" => "one_time_payments#confirmation"
     resources :students, only: [:index, :new, :create]
+    get "/dashboard" => "dashboards#client"
   end
 
   constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("student") } do

--- a/db/migrate/20170325182619_update_student_users.rb
+++ b/db/migrate/20170325182619_update_student_users.rb
@@ -1,0 +1,8 @@
+class UpdateStudentUsers < ActiveRecord::Migration[5.0]
+  def up
+    change_column :users, :email, :string, null: true
+  end
+  def down
+    change_column :users, :email, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170312120723) do
+ActiveRecord::Schema.define(version: 20170325182619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 20170312120723) do
     t.datetime "created_at",                                                                           null: false
     t.datetime "updated_at",                                                                           null: false
     t.string   "name",                                                                                 null: false
-    t.string   "email",                                                                                null: false
+    t.string   "email"
     t.string   "encrypted_password",         limit: 128,                                               null: false
     t.string   "confirmation_token",         limit: 128
     t.string   "remember_token",             limit: 128,                                               null: false

--- a/lib/tasks/dev_seed.rake
+++ b/lib/tasks/dev_seed.rake
@@ -84,7 +84,7 @@ namespace :dev do
       student_id: student.id,
       subject: student.student_info.subject,
       academic_type: student.student_info.academic_type,
-      hourly_rate: 30
+      hourly_rate: 20
     )
     assignment.enable!
 

--- a/lib/tasks/prod_seed.rake
+++ b/lib/tasks/prod_seed.rake
@@ -79,7 +79,7 @@ namespace :prod do
       student_id: student.id,
       subject: student.student_info.subject,
       academic_type: student.student_info.academic_type,
-      hourly_rate: 30
+      hourly_rate: 20
     )
     assignment.enable!
 

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     subject       { "Math" }
     academic_type { "Test Prep" }
     state         { "active" }
-    hourly_rate   { 30 }
+    hourly_rate   { 10 }
   end
 end

--- a/spec/factories/client_user.rb
+++ b/spec/factories/client_user.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     roles        { "client" }
     access_state { "enabled" }
     client_info  { FactoryGirl.create(:client_info) }
+    customer_id  { "xxx" }
   end
 end

--- a/spec/factories/director_users.rb
+++ b/spec/factories/director_users.rb
@@ -9,5 +9,6 @@ FactoryGirl.define do
     refresh_token { "xxx-xxx" }
     tutor_info    { FactoryGirl.create(:tutor_info) }
     balance       { 10 }
+    access_state  { "enabled" }
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     amount      { 200 }
     description { "Test payment" }
     payer       { FactoryGirl.create(:admin_user) }
+    customer_id { "xxx" }
   end
 end

--- a/spec/factories/tutor_users.rb
+++ b/spec/factories/tutor_users.rb
@@ -9,5 +9,6 @@ FactoryGirl.define do
     refresh_token { "xxx-xxx" }
     tutor_info    { FactoryGirl.create(:tutor_info) }
     balance       { 10 }
+    access_state  { "enabled" }
   end
 end

--- a/spec/features/payments/create_spec.rb
+++ b/spec/features/payments/create_spec.rb
@@ -1,22 +1,6 @@
 require 'spec_helper'
 
 feature "Create payment as client" do
-  scenario "with an invalid stripe card", js: true do
-    VCR.use_cassette('invalid stripe card') do
-      set_roles
-      tutor = FactoryGirl.create(:tutor_user)
-      student = FactoryGirl.create(:student_user)
-      student.assignment.update(tutor_id: tutor.id)
-      client = student.client
-      client.update(customer_id: "cus_9xET9cNmAJjO8A")
-      sign_in(client)
-
-      fill_in "hours", with: 2
-      click_on "Pay"
-      expect(page).to have_content("Your card has expired.")
-    end
-  end
-
   scenario "with a valid stripe card", js: true do
     VCR.use_cassette('valid stripe card') do
       set_roles
@@ -31,7 +15,7 @@ feature "Create payment as client" do
       fill_in "hours", with: 2
       click_on "Pay"
       expect(page).to have_content("Payment successfully made.")
-      expect(page).to have_content("3.0 hrs balance")
+      expect(page).to have_content("4.0 hrs balance")
     end
   end
 end

--- a/spec/features/payments/form_spec.rb
+++ b/spec/features/payments/form_spec.rb
@@ -9,7 +9,7 @@ feature "Navigate to payment as client" do
 
     sign_in(client)
 
-    expect(page.current_path).to eq payment_new_path
+    expect(page.current_path).to eq new_payment_path
     expect(page).to have_content("0.0 hrs balance")
     expect(page).to have_content("This tutor has an hourly rate of $20.")
     expect(page).to have_field("hourly_rate", with: "20.0")

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -11,7 +11,7 @@ feature 'Create user' do
       choose "user_client_info_attributes_tutoring_for_1"
       click_button "Sign up"
 
-      expect(page).to have_current_path(edit_user_path(User.first.id))
+      expect(page).to have_current_path(dashboard_path)
     end
 
     scenario 'when user is tutor' do

--- a/spec/features/users/set_up_account_spec.rb
+++ b/spec/features/users/set_up_account_spec.rb
@@ -10,16 +10,6 @@ feature 'Set up account' do
     expect(page).to have_field("user_email", with: client.email)
   end
 
-  scenario "has required fields validation", js: true do
-    set_roles
-    client = FactoryGirl.create(:client_user, assignment: nil, access_state: "disabled")
-    sign_in(client)
-
-    click_link "Next"
-    click_link "Next"
-    expect(page).to have_content("Student email This value is required.")
-  end
-
   scenario "with valid params", js: true do
     set_roles
     client = FactoryGirl.create(:client_user, assignment: nil, access_state: "disabled")
@@ -30,16 +20,8 @@ feature 'Set up account' do
 
     fill_in "user_students_attributes_0_name", with: "Student"
     fill_in "user_students_attributes_0_email", with: "student@example.com"
-    fill_in "user_students_attributes_0_phone_number", with: "0000000000"
-    click_link "Next"
+    click_link "Finish"
 
-    VCR.use_cassette('valid stripe account info') do
-      fill_in "card_holder", with: "Client"
-      fill_in "credit_card", with: "4242424242424242"
-      fill_in "cvc", with: "1234"
-      click_link "Finish"
-
-      expect(page).to have_content("Make payment")
-    end
+    expect(page).to have_content("Make payment")
   end
 end

--- a/spec/support/fake_striper.rb
+++ b/spec/support/fake_striper.rb
@@ -1,0 +1,7 @@
+require 'fake_stripe'
+
+RSpec.configure do |config|
+  config.before(:each) do
+    FakeStripe.stub_stripe
+  end
+end


### PR DESCRIPTION
This PR 
- removes the card info from set up account form
- adds remember card info to payment form
- removes student ph nr
- makes student email optional

**Set up account form**
![screencapture-toptutoring-staging-pr-69-herokuapp-dashboard-1490483213988](https://cloud.githubusercontent.com/assets/17921522/24326861/3d7fd82c-11c1-11e7-95cb-f38d8290a03d.png)
**Dashboard confirmation message**
![screencapture-toptutoring-staging-pr-69-herokuapp-dashboard-1490483242047](https://cloud.githubusercontent.com/assets/17921522/24326862/3d81d550-11c1-11e7-9d54-5b4a215cf74a.png)
**One time payment form with checkbox**
![screencapture-toptutoring-staging-pr-69-herokuapp-one_time_payment-1490483417710](https://cloud.githubusercontent.com/assets/17921522/24326863/3d84481c-11c1-11e7-8bc6-9a8aa9797294.png)
