### PR TITLE
Make tutors have_many subjects so that more than one tutor can have profile subjects

### DIFF
--- a/app/models/tutor_profile.rb
+++ b/app/models/tutor_profile.rb
@@ -1,0 +1,5 @@
+class TutorProfile < ActiveRecord::Base
+  # Associations
+  belongs_to :user
+  belongs_to :subject
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,8 @@ class User < ActiveRecord::Base
   has_many :emails, class_name: "Email", foreign_key: "tutor_id", dependent: :destroy
   has_many :user_roles
   has_many :roles, through: :user_roles
-  has_many :subjects
+  has_many :tutor_profiles
+  has_many :subjects, through: :tutor_profiles
   accepts_nested_attributes_for :subjects
   attr_encrypted :access_token, key: ENV.fetch("ENCRYPTOR_KEY")
   attr_encrypted :refresh_token, key: ENV.fetch("ENCRYPTOR_KEY")

--- a/db/migrate/20170513013142_create_tutor_profiles_for_tutors.rb
+++ b/db/migrate/20170513013142_create_tutor_profiles_for_tutors.rb
@@ -1,0 +1,9 @@
+class CreateTutorProfilesForTutors < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :subjects, :user_id
+    create_table :tutor_profiles do |t|
+      t.references :user, index: true
+      t.references :subject, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170502162940) do
+ActiveRecord::Schema.define(version: 20170513013142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,9 +106,14 @@ ActiveRecord::Schema.define(version: 20170502162940) do
   end
 
   create_table "subjects", force: :cascade do |t|
-    t.string  "name"
+    t.string "name"
+  end
+
+  create_table "tutor_profiles", force: :cascade do |t|
     t.integer "user_id"
-    t.index ["user_id"], name: "index_subjects_on_user_id", using: :btree
+    t.integer "subject_id"
+    t.index ["subject_id"], name: "index_tutor_profiles_on_subject_id", using: :btree
+    t.index ["user_id"], name: "index_tutor_profiles_on_user_id", using: :btree
   end
 
   create_table "user_roles", force: :cascade do |t|
@@ -153,5 +158,4 @@ ActiveRecord::Schema.define(version: 20170502162940) do
   add_foreign_key "payments", "users", column: "payee_id"
   add_foreign_key "payments", "users", column: "payer_id"
   add_foreign_key "student_infos", "users"
-  add_foreign_key "subjects", "users"
 end


### PR DESCRIPTION
This makes subjects a `has_many:through` for a many to many relationship.

I thought that `tutor_profiles` would be the appropriate place to make the join table since this is information about what the tutor can tutor and it is part of their 'profile'

This means we can now find all the tutors that can tutor a particular subject, as well as all the subjects a tutor can tutor, which we could not do before.

I'll be merging this in, but please review @scorchio36 and @ojameso and @alexandrapersea for insight.