### PR TITLE
Remove clearance's default signup path

### DIFF
--- a/app/views/application/_authentication_header.html.erb
+++ b/app/views/application/_authentication_header.html.erb
@@ -29,7 +29,7 @@
                 <%= link_to "Sign in", sign_in_path, class: "page-link logo-dark" %>
               </li>
               <li>
-                <%= link_to "Sign up", new_users_client_path, class: "page-link logo-dark" %>
+                <%= link_to "Sign up", client_sign_up_path, class: "page-link logo-dark" %>
               </li>
             </ul>
         </div>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -7,7 +7,7 @@
             <a href="http://www.toptutoring.com/how_it_works" class="uppercase mb16 fade-on-hover footer-link first">HOW IT WORKS</a>
           </li>
           <li>
-            <%= link_to "Find a tutor", new_users_client_path, class: "uppercase mb16 fade-on-hover footer-link" %>
+            <%= link_to "Find a tutor", client_sign_up_path, class: "uppercase mb16 fade-on-hover footer-link" %>
           </li>
           <li>
             <a href="http://www.toptutoring.com/careers" class="uppercase mb16 fade-on-hover footer-link">Careers</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get "/confirmation" => "one_time_payments#confirmation"
   get "payment" => "pages#payment"
   get "/profile" => "users#profile"
+  get '/sign_up' => "users/clients#new", as: "client_sign_up"
 
   # Omniauth routes
   get "/auth/dwolla/callback", to: "auth_callbacks#create"
@@ -89,10 +90,11 @@ Rails.application.routes.draw do
 
   # Users signup.
   namespace :users do
-    resources :clients, only: [:new, :create]
+    resources :clients, only: [:create]
     resources :tutors, only: [:new, :create]
     get "tutors/signup" => "tutors#signup"
   end
+
 
   resources :engagements do
     member do

--- a/spec/features/tutoring_flow/tutoring_flow_spec.rb
+++ b/spec/features/tutoring_flow/tutoring_flow_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 #  let(:student) { FactoryGirl.create(:student_user, client: client) }
 #
 #  scenario "client signup and set up account", js: true do
-#    visit new_users_client_path
+#    visit client_sign_up_path
 #
 #    fill_in "user_name", with: "Client"
 #    fill_in "user_email", with: "client@example.com"

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Create user' do
   context "with valid params" do
     scenario 'when user is student' do
-      visit new_users_client_path
+      visit client_sign_up_path
 
       fill_in "user_name", with: 'student'
       fill_in "user_email", with: 'student@example.com'
@@ -28,7 +28,7 @@ feature 'Create user' do
 
   context "with invalid params" do
     scenario 'when user is student' do
-      visit new_users_client_path
+      visit client_sign_up_path
 
       fill_in "user_name", with: 'student'
       fill_in "user_email", with: 'student'


### PR DESCRIPTION
Change client signup path to "sign/up" in order to fix [this error](https://app.bugsnag.com/plexmate/top-tutoring-1/errors/5926fe768c0d8d001b604673?event_id=5926fe768c0d8d001b604672&i=sk&m=nw)

**Must be merged with [pr #31](https://github.com/plexmate/ttutoring/pull/31)**
