### PR TITLE
Refactored how to access name

### DIFF
--- a/app/decorators/engagement_presenter.rb
+++ b/app/decorators/engagement_presenter.rb
@@ -10,7 +10,7 @@ class EngagementPresenter < SimpleDelegator
   end
 
   def student_name
-    @engagement.student_name
+    @engagement.student.try(:name)
   end
 
   def tutor_name


### PR DESCRIPTION
On tutors' portal, student name was not showing up properly. Refactored engagements presenter to correctly grab student's name. Student name column is not necessary on engagement model and therefore should be deprecated. 