### PR TITLE
Link top left icon to ttutoring instead of root path.

### DIFF
--- a/app/views/application/_authentication_header.html.erb
+++ b/app/views/application/_authentication_header.html.erb
@@ -1,7 +1,7 @@
 <nav>
   <div class="nav-bar">
     <div class="module left">
-        <a href="<%= root_path %>">
+        <a href="<%= "https://toptutoring.com/" %>">
           <div class="vnu">
             <img src="<%= image_url('topTutoringFinal.png') %>" class="logo logo-dark">
           </div>


### PR DESCRIPTION
This PR send the user to the Top Tutoring front page website instead of the rails app 'root_path' when the upper left Top Tutoring icon (seen before client logs in) is clicked.