### PR TITLE
Removed use of Presenter in Dashboard Student view

### DIFF
--- a/app/views/dashboards/_students.html.erb
+++ b/app/views/dashboards/_students.html.erb
@@ -16,14 +16,17 @@
             </tr>
           </thead>
             <tbody>
-              <% @tutor_engagements.each do |engagement|
-                representer = EngagementPresenter.new(engagement) %>
+              <% @tutor_engagements.each do |engagement| %>
                 <tr>
-                <td><%= representer.student_name %></td>
-                <td class="text-center"><%= representer.subject %></td>
-                <td class="text-center"><%= representer.engagement_academic_type %></td>
-                <td class="text-center"><span class="label label-outline label-warning"><%= representer.state %></span></td>
-                <td class="text-center"><%= representer.student_credit %> hrs</td>
+                <td><%= engagement.student_name %></td>
+                <td class="text-center"><%= engagement.subject %></td>
+                <td class="text-center"><%= engagement.academic_type %></td>
+                <td class="text-center"><span class="label label-outline label-warning"><%= engagement.state %></span></td>
+                <% if engagement.academic_type == "Academic" %>
+                  <td class="text-center"><%= engagement.client.academic_credit %> hrs</td>
+                <% else %>
+                  <td class="text-center"><%= engagement.client.test_prep_credit %> hrs</td>
+                <% end %>
               </tr>
             <% end %>
           </tbody>

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -24,9 +24,9 @@ feature 'Dashboard Index' do
 
     expect(page).to have_content(active_engagement.student.name)
     expect(page).to have_content(active_engagement.subject)
-    expect(page).to have_content(active_presenter.engagement_academic_type)
+    expect(page).to have_content(active_engagement.academic_type)
     expect(page).to have_content(active_engagement.state)
-    expect(page).to have_content(active_presenter.student_credit)
+    expect(page).to have_content(active_engagement.client.test_prep_credit)
   end
 
   scenario 'when user is director' do


### PR DESCRIPTION
The presenter was causing a 500 and so a simplified view was used
instead of a complex presenter.