### PR TITLE
Address 500 for client payment issue

### DIFF
--- a/app/controllers/one_time_payments_controller.rb
+++ b/app/controllers/one_time_payments_controller.rb
@@ -15,12 +15,10 @@ class OneTimePaymentsController < ApplicationController
 
     begin
       if params[:save_payment_info] && current_user
-        customer = payment_service.retrieve_customer
-        current_user.customer_id = customer.id
-        current_user.save!
-        payment = payment_service.create_charge_with_customer
+        payment_service.save_payment_info
+        payment = payment_service.create_charge
       else
-        payment = payment_service.create_charge_with_token
+        payment = payment_service.create_charge
       end
 
       payment_service.process!(payment) if current_user

--- a/app/views/pages/payment.html.erb
+++ b/app/views/pages/payment.html.erb
@@ -2,7 +2,9 @@
 <div class="row">
   <% if @invoices.empty? %>
     <div>
+      <section class="payment-section one-time-payment col-md-6">
       <%= render "payment_form" %>
+      </section>
     </div>
   <% else %>
     <div class="col-md-5 col-md-offset-2">
@@ -106,7 +108,9 @@
   <% end %> <!-- first if statement -->
 
   <div id="payment_section" style="visibility:hidden;">
-    <%= render "payment_form" %>
+    <section class="payment-section one-time-payment col-md-6">
+      <%= render "payment_form" %>
+    </section>
   </div>
 
 </div>

--- a/app/views/payments/_payment_form.html.erb
+++ b/app/views/payments/_payment_form.html.erb
@@ -1,4 +1,3 @@
-<section class="payment-section one-time-payment col-md-6">
 <%= form_for @payment, :html => { :class => "form-horizontal payment-form", id: "payment-form" } do |f| %>
   <fieldset class="credit_card">
 
@@ -140,5 +139,4 @@ just the last four digits followed by a special 3-digit code. This 3-digit code 
   <%= hidden_field_tag :payer_email, current_user.email %>
 
 <% end %>
-</section>
 <%= javascript_include_tag "#{STRIPE_JS_HOST}/v2/" %>

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -1,10 +1,13 @@
 <div id="flash_message">
 </div>
+<h2>Payment</h2>
 </br>
 <div class="row">
   <% if @invoices.empty? || @suggested_hours == 0 %>
     <div>
+      <section class="payment-section col-md-8">
       <%= render "payment_form" %>
+      </section>
     </div>
   <% else %>
     <div class="col-md-5 col-md-offset-1">
@@ -112,7 +115,9 @@
     </div>
 
     <div id="payment_section" style="visibility:hidden;">
+      <section class="payment-section one-time-payment col-md-6">
       <%= render "payment_form" %>
+      </section>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Customers were receiving 500 when trying to make payment on the payment page. This was caused because of buggy code. Along with the fix, some moderate refactoring was done, but should be addressed even further. Views were also changed because the layout for the payment form on the payment page was not being displayed nicely.