### PR TITLE
Make certain subjects test prep

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -24,6 +24,7 @@ class DashboardsController < ApplicationController
       @engagements = current_user&.client_engagements || current_user&.student_engagements
       @availability_engagement = current_user&.student_engagements&.first ||
 	      current_user&.client_engagements&.first
+      correct_tutoring_type
       render :client
     end
   end
@@ -52,5 +53,12 @@ class DashboardsController < ApplicationController
 
   def option_array(engagement, credit)
     ["#{engagement.student_name} for #{engagement.subject} - #{credit} Credits", engagement.id]
+  end
+
+  def correct_tutoring_type
+    subject = Subject.find_by(name: current_user.signup.subject)
+    test_prep = subject.test_prep?
+    @test_prep_selected = test_prep ? "selected" : ""
+    @tutoring_type = test_prep ? "Test_Prep" : "Academic"
   end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -3,18 +3,4 @@ module DashboardHelper
     "Hello #{current_user.name}, your #{ current_user.has_role?("director") ? 'administrator' : 'director' }
       is using Dwolla in order to make transfers. Please click the button below to authenticate with Dwolla."
   end
-
-  def get_academic_type_from_subject
-    subject = current_user.client_info.subject
-
-    if(subject.include?("ACT") || subject.include?("PSAT") || subject.include?("CASHSEE") || subject.include?("CHSPE") ||
-      subject.include?("CLEP") || subject.include?("CPA") || subject.include?("EOC") || subject.include?("GED") || subject.include?("GMAT") ||
-      subject.include?("GRE") || subject.include?("PCAT") || subject.include?("SAT") || subject.include?("TOEFL") || subject.include?("TOPS") ||
-      subject.include?("WISC") || subject.include?("WPPSI"))
-
-      "Test_Prep"
-    else
-      "Academic"
-    end
-  end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,5 +1,14 @@
 class Subject < ActiveRecord::Base
   validates_uniqueness_of :name
 
+  TEST_PREP_SUBJECTS = %w(ACT PSAT CASHEE CHSPE
+                          CLEP CPA EOC GED GMAT
+                          GRE PCAT SAT TOEFL TOPS
+                          WISC WPPSI).freeze
+
   belongs_to :user
+
+  def test_prep?
+    (TEST_PREP_SUBJECTS.map { |subject| name.include?(subject) }).include?(true)
+  end
 end

--- a/app/views/users/_client_fields.html.erb
+++ b/app/views/users/_client_fields.html.erb
@@ -2,13 +2,11 @@
   <div class="col-md-6">
     <div class="form-group">
       <h5>Tutoring Type (Based on your selected subject)</h5>
-      <!--<label for="info_academic_type">Tutoring Type</label>-->
-
       <select required="required" name="info[academic_type]" id="info_academic_type" style="cursor:not-allowed" disabled>
         <option value="Academic">Academic</option>
-        <option value="Test_Prep" <%= if get_academic_type_from_subject == 'Test_Prep'; 'selected'; end; %>>Test Preparation</option>
+        <option value="Test_Prep" <%= @test_prep_selected %>>Test Preparation</option>
       </select>
-      <input type="hidden" name="info[academic_type]" value="<%= get_academic_type_from_subject %>"/>
+      <input type="hidden" name="info[academic_type]" value="<%= @tutoring_type %>"/>
     </div>
   </div>
 </div>

--- a/app/views/users/_student_fields.html.erb
+++ b/app/views/users/_student_fields.html.erb
@@ -16,9 +16,9 @@
           <h5>Tutoring Type (Based on your selected subject)</h5>
           <select name="info[academic_type]" class="students-academic-type" style="cursor:not-allowed" disabled>
             <option value="Academic">Academic</option>
-            <option value="Test_Prep" <%= if get_academic_type_from_subject == 'Test_Prep'; 'selected'; end; %>>Test Preparation</option>
+            <option value="Test_Prep" <%= @test_prep_selected %>>Test Preparation</option>
           </select>
-          <input type="hidden" name="info[academic_type]" value="<%= get_academic_type_from_subject %>"/>
+          <input type="hidden" name="info[academic_type]" value="<%= @tutoring_type %>"/>
         </div>
       </div>
       <div class="col-md-4">


### PR DESCRIPTION
This PR will now allow a client's tutoring type to be preselected to 'Test_Prep', if the subject chosen by the client is a test preparation subject (ACT, SAT, etc.). This will prevent any confusion arising from differing  tutoring type costs on the payment page and will make the process of signing up a little easier.
The tutoring type select field is now read-only.