### PR TITLE
Fix text for Engagement Edit button

### DIFF
--- a/app/decorators/engagement_presenter.rb
+++ b/app/decorators/engagement_presenter.rb
@@ -44,4 +44,8 @@ class EngagementPresenter < SimpleDelegator
       MultiCurrencyAmount.from_cent(self.client.test_prep_rate.cents, MultiCurrencyAmount::APP_DEFAULT_CURRENCY)
     end
   end
+
+  def text_for_edit_button
+    @engagement.tutor_id.nil? ? "Assign tutor" : "Edit"
+  end
 end

--- a/app/views/engagements/index.html.erb
+++ b/app/views/engagements/index.html.erb
@@ -33,7 +33,7 @@
                     <td class="text-center"><span class="label label-outline label-warning"><%= representer.state %></span></td>
                     <td class="text-center">
                       <%= link_to edit_engagement_path(representer.id) do %>
-                        <button type="button" class="btn btn-outline btn-success">Edit</button>
+                        <button type="button" class="btn btn-outline btn-success"><%= representer.text_for_edit_button %></button>
                       <% end %>
                     </td>
                     <% if representer.updated? && representer.pending? %>


### PR DESCRIPTION
https://trello.com/c/KwUEPzB9/126-edit-button-should-become-assign-tutor

This PR displays the text of the edit button as either "Assign" or "Edit", depending on whether an engagement has been assigned a tutor.

![screen shot 2017-09-01 at 11 15 17 pm](https://user-images.githubusercontent.com/9409378/29993422-7775a746-8f6b-11e7-89f9-4328b3f1e983.png)

