### PR TITLE
Moved notification email on sign up to workers

### DIFF
--- a/app/controllers/users/clients_controller.rb
+++ b/app/controllers/users/clients_controller.rb
@@ -11,8 +11,7 @@ module Users
     def create
       @user = Clearance.configuration.user_model.new(signups_params)
       if @user.save
-        UserNotifierMailer.send_signup_email(@user).deliver_now
-        NewClientNotifier.perform(@user, User.admin_and_directors)
+        SendNotifierEmailsWorker.perform_async(@user)
         sign_in(@user)
         redirect_to :root
       else

--- a/app/workers/send_notifier_emails_worker.rb
+++ b/app/workers/send_notifier_emails_worker.rb
@@ -1,0 +1,9 @@
+class SendNotifierEmailsWorker
+  include Sidekiq::Worker
+
+  def perform(new_user_id)
+    new_user = User.find(new_user_id)
+    UserNotifierMailer.send_signup_email(new_user).deliver_now
+    NewClientNotifier.perform(new_user, User.admin_and_directors)
+  end
+end


### PR DESCRIPTION
Emails were being sent out within the controller which could slow down
the service. Since the emails are not necessay to serve the immediate
needs of the client, the emails were moved to a worker.