### PR TITLE
Add assigned tutor and blank on engagement edit form dropdown

### DIFF
--- a/app/views/engagements/edit.html.erb
+++ b/app/views/engagements/edit.html.erb
@@ -10,7 +10,7 @@
           <%= f.label :tutor_id, "Tutor" %>
           <div class="select-option">
             <i class="ion-chevron-down"></i>
-            <%= f.select :tutor_id, options_from_collection_for_select(@tutors, :id, :name)%>
+            <%= f.select :tutor_id, options_from_collection_for_select(@tutors, :id, :name, @engagement.tutor_id), { include_blank: true }%>
           </div>
 
           <div class="form-group">


### PR DESCRIPTION
The edit form for Engagements now has the engagement's tutor as the default selected option in the dropdown. If there is no tutor for the engagement, a blank is selected.

https://trello.com/c/I2xzaoCh/133-make-assigned-tutor-the-default-option-in-dropdown-on-engagement-edit-form

![engagement_edit_form](https://user-images.githubusercontent.com/9409378/30093500-9d9914d2-927a-11e7-9b3a-a0fabe3cc143.gif)
