### PR TITLE
Added exception handling for Admin Funding Source Page

### DIFF
--- a/app/controllers/admin/funding_sources_controller.rb
+++ b/app/controllers/admin/funding_sources_controller.rb
@@ -41,6 +41,9 @@ module Admin
 
     def get_funding_sources
       @funding_sources = DwollaService.new.funding_sources
+    rescue DwollaV2::Error
+      @funding_sources = []
+      flash[:danger] = "There was an error while retrieving available Funding Sources. Please make sure you have authenticated with Dwolla."
     end
 
     def check_funding_source


### PR DESCRIPTION
The funding source edit page was throwing a 500 because it could not
handle Dwolla errors. An exception handling for Dwolla was added that
asks the user to reauthenticate with Dwolla.