### PR TITLE
Display 2 decimal places in engagement hourly rate

### DIFF
--- a/app/decorators/engagement_presenter.rb
+++ b/app/decorators/engagement_presenter.rb
@@ -39,9 +39,9 @@ class EngagementPresenter < SimpleDelegator
 
   def hourly_rate
     if self.academic_type.casecmp('academic') == 0
-      self.client.academic_rate.format
+      self.client.academic_rate
     else
-      self.client.test_prep_rate.format
+      self.client.test_prep_rate
     end
   end
 

--- a/app/views/engagements/index.html.erb
+++ b/app/views/engagements/index.html.erb
@@ -29,7 +29,7 @@
                     <td><%= representer.tutor_name %></td>
                     <td><%= representer.subject %></td>
                     <td class="text-center"><%= representer.engagement_academic_type %></td>
-                    <td class="text-center"><%= representer.hourly_rate %></td>
+                    <td class="text-center"><%= number_to_currency(representer.hourly_rate) %></td>
                     <td class="text-center"><span class="label label-outline label-warning"><%= representer.state %></span></td>
                     <td class="text-center">
                       <%= link_to edit_engagement_path(representer.id) do %>


### PR DESCRIPTION
Fixes a bug where the engagement's client's hourly rate was displaying only one decimal place (e.g. 25.0).

Trello ticket: https://trello.com/c/tB7L3pQ3/139-under-engagements-edit-client-hourly-rate-to-have-two-zeros-after-decimal-point

![screen shot 2017-09-07 at 11 34 27 pm](https://user-images.githubusercontent.com/9409378/30199116-0dae5f32-9426-11e7-9aa1-8085a1a2532f.png)

We were dividing the amount for the hourly rate by 100.0 in `MultiCurrencyAmount`, which is why  we were getting this issue (i.e. 2500 / 100.0 == 25.0). Since we're using the [money-rails](https://github.com/RubyMoney/money-rails) gem, I used `Money#format` to get the desired format to display in the engagements view. It is unclear to me exactly what the `MultiCurrencyAmount` class is for (since money-rails can handle multiple currencies).