### PR TITLE
Adds student dashboard

### DIFF
--- a/app/controllers/availability_controller.rb
+++ b/app/controllers/availability_controller.rb
@@ -5,7 +5,7 @@ class AvailabilityController < ApplicationController
 
   def new
     @days = DAYS
-    @engagements = Engagement.where(client_id: current_user.id)
+    @engagements = current_user.engagements
     @next_engagement = Engagement.find_by(id: params[:engagement_id])
     if @next_engagement.nil?
       @availabilities = []

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -29,7 +29,9 @@ class DashboardsController < ApplicationController
   end
 
   def student
-    redirect_to profile_path
+    @engagements = current_user.engagements.includes(:tutor, :availabilities)
+    @engagements = @engagements.sort_by { |engagement| engagement.try(:tutor).try(:name) }
+    @academic_type = current_user.academic_types_engaged
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ActiveRecord::Base
   has_many :students, class_name: "User", foreign_key: "client_id"
   accepts_nested_attributes_for :students
   belongs_to :client, class_name: "User", foreign_key: "client_id"
-  has_many :engagements, ->(user) { unscope(:where).where("tutor_id = ? OR client_id = ? OR student_name = ?", user.id, user.id, user.name) }
+  has_many :engagements, ->(user) { unscope(:where).where("tutor_id = ? OR client_id = ? OR student_id = ?", user.id, user.id, user.id) }
   has_many :tutor_engagements, class_name: "Engagement", foreign_key: "tutor_id", dependent: :destroy
   has_many :client_engagements, class_name: "Engagement", foreign_key: "client_id", dependent: :destroy
   has_many :student_engagements, class_name: "Engagement", foreign_key: "student_id", dependent: :destroy

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -28,6 +28,8 @@
     <ul class="list-unstyled navigation mb-0">
       <% if current_user.has_role?("client") %>
         <%= render "application/menu_links/client" %>
+      <% elsif current_user.has_role?("student") %>
+        <%= render "application/menu_links/student" %>
       <% elsif current_user.has_role?("admin") || current_user.has_role?("director") %>
         <li class="panel"><a href="/dashboard"><i class="ion-ios-home-outline bg-purple"></i><span class="sidebar-title">Dashboard</span></a></li>
       <% if current_user.has_role?("admin") %>

--- a/app/views/application/menu_links/_student.html.erb
+++ b/app/views/application/menu_links/_student.html.erb
@@ -1,0 +1,3 @@
+<% if current_user.enabled? %>
+  <li class="panel"><a href="/dashboard"><i class="ion-ios-home-outline bg-purple"></i><span class="sidebar-title">Dashboard</span></a></li>
+<% end %>

--- a/app/views/dashboards/client.html.erb
+++ b/app/views/dashboards/client.html.erb
@@ -4,7 +4,7 @@
   <div class="widget-body col-lg-8 col-md-12 col-sm-12 pull-left">
     <!-- tutor blocks -->
     <%= render "dashboards/clients/tutor_list" %>
-    <!-- balance block -->
+    <!-- comment block -->
     <%= render "dashboards/clients/comment_form" %>
   </div>
   <!-- left main end -->

--- a/app/views/dashboards/student.html.erb
+++ b/app/views/dashboards/student.html.erb
@@ -1,1 +1,13 @@
 <%= render "menu" %>
+<% if current_user.enabled? %>
+  <!-- left main -->
+  <div class="widget-body col-lg-12 col-md-12 col-sm-12 pull-left">
+    <!-- tutor blocks -->
+    <%= render "dashboards/clients/tutor_list" %>
+    <!-- balance block -->
+    <%= render "dashboards/clients/comment_form" %>
+  </div>
+  <!-- left main end -->
+<% else %>
+  <%= render "users/set_up_account" %>
+<% end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,8 @@ Rails.application.routes.draw do
 
   constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("student") } do
     get "/dashboard" => "dashboards#student"
+    resources :availability, only: [:new, :create, :update, :edit]
+    post "/availability/dropdown_change" => "availability#dropdown_change"
   end
 
   constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("contractor") } do


### PR DESCRIPTION
Previously, the dashboard for students was blank. Now, it incorporates the widgets that show them their tutors as well as a contact form. A student side menu was also added so that students can navigate back to the dashboard after they visit their profile page or update their availability.

Student dash was previously empty, but now...
![image](https://user-images.githubusercontent.com/24426214/30712655-a0c1b648-9ec1-11e7-8107-ce08cbc8053b.png)