### PR TITLE
Fixes footer and sign in form styles

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,6 +1,42 @@
 $light_blue: #59a4f0; // For font, backgrounds, and borders
 $text_default: #737373; // To revert to default font color
 
+.sign-in-form {
+  max-width: 480px;
+  width: 95%;
+  margin: auto;
+}
+
+.footer-2 .footer-left ul {
+  min-width: 160px;
+  width: 25%;
+}
+
+.footer-2 .footer-left ul li {
+  display: inline-block;
+  width: 100%;
+}
+
+@media (min-width: 700px) {
+  .footer-2 .footer-left ul {
+    width: 50%;
+  }
+
+  .footer-2 .footer-left ul li {
+    width: 49%;
+  }
+}
+
+@media (min-width: 1090px) {
+  .footer-2 .footer-left ul {
+    min-width: 700px;
+  }
+
+  .footer-2 .footer-left ul li {
+    width: auto;
+  }
+}
+
 .unfloat {
   float: none;
 }

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <img src="<%= image_url('topTutoringFinal.png') %>" class="logo-img">
   </h1>
   <div class="row">
-  <div class="col-md-4 col-md-offset-4 text-center">
+  <div class="sign-in-form text-center">
     <%= form_for :session, url: session_path, html: { class: "form-horizontal login" } do |form| %>
       <div class="email col-xs-12">
         <%= form.label :email, class: "sr-only"  %>


### PR DESCRIPTION
The footer's links were getting distorted when viewing on mobile. This pr fixes that issues. Also, the signup form has also been adjusted so it's not jittery when resizing pages.

What it was before
![image](https://user-images.githubusercontent.com/24426214/31302919-a4f627d0-aaba-11e7-9609-9981b731db69.png)

What it is now
![image](https://user-images.githubusercontent.com/24426214/31302921-adafd75e-aaba-11e7-9c4c-e9afdbeab969.png)
![image](https://user-images.githubusercontent.com/24426214/31302922-b3114840-aaba-11e7-816b-377f16cd8d03.png)
