### PR TITLE
Adds ttutoring auto-deploy script

### DIFF
--- a/bin/auto_deploy.rb
+++ b/bin/auto_deploy.rb
@@ -1,0 +1,116 @@
+require 'date'
+require 'english'
+
+class DeploymentError < StandardError
+  attr_reader :error
+  def initialize(error, msg = "Deployment Error")
+    @error = error
+    super(msg)
+  end
+end
+
+class Deployer
+  TTUTORING_PATH = "INSTALL_TTUTORING_PATH".freeze
+  PATH_COMMAND = "cd #{TTUTORING_PATH}".freeze
+  TERMINAL_NOTIFIER = "INSTALL_TERMINAL_NOTIFIER_PATH".freeze
+  BRANCH_NAME = "add-korean-daily-ad-page".freeze
+
+  def process
+    checkout_to_deploy_branch
+    set_dates
+    deploy
+    return_to_user_branch
+  rescue DeploymentError => e
+    notify e.message + ": " + e.error
+  end
+
+  private
+
+  def checkout_to_deploy_branch
+    if working_tree_clean?
+      set_user_branch
+      `#{PATH_COMMAND} && git checkout #{BRANCH_NAME} && git pull`
+      raise DeploymentError.new("Could not switch to #{BRANCH_NAME} branch") if shell_error
+    else
+      raise DeploymentError.new("Current branch is not clean. Unable to process.")
+    end
+  end
+
+  def working_tree_clean?
+    `#{PATH_COMMAND} && git status` =~ /working tree clean/
+  end
+
+  def set_user_branch
+    branch_list = `#{PATH_COMMAND} && git branch`
+    @user_branch = branch_list.match(/\*\s+(.+)\n/)[1]
+  end
+
+  def return_to_user_branch
+    `#{PATH_COMMAND} && git checkout #{@user_branch}`
+  end
+
+  def set_dates
+    log_message = `#{PATH_COMMAND} && git log -1`
+    date_string = log_message.split("\n").find { |string| string.match("Date:   ") }
+    @last_update = Date.parse date_string
+    @today = Date.today
+  end
+
+  def deploy
+    if needs_deployment?
+      execute_deployment
+      notify deployment_message
+    else
+      notify no_deployment_message
+    end
+  end
+
+  def needs_deployment?
+    return false if @last_update == @today
+    ttutoring_posts_dir = Dir.new(TTUTORING_PATH + "/_posts")
+    grab_posts_to_publish(ttutoring_posts_dir)
+    STDOUT.puts @posts_to_publish
+    @posts_to_publish.any?
+  end
+
+  def grab_posts_to_publish(dir)
+    @posts_to_publish = []
+    dir.each do |file|
+      match = file.match(/(\d+-\d+-\d+).+/)
+      next unless match
+      date = Date.parse(match[1])
+      @posts_to_publish << match[0] if date.between?(@last_update, @today)
+    end
+  end
+
+  def execute_deployment
+    commit_args = "--allow-empty -m 'Publishing article(s): #{@posts_to_publish.join(', ')}'"
+    @git_log = `#{PATH_COMMAND} && git commit #{commit_args} && git push`
+    raise DeploymentError.new("Failure while pushing to #{BRANCH_NAME}") if shell_error
+  end
+
+  def deployment_message
+    publish_count = @posts_to_publish.count
+    if publish_count > 1
+      publish_message = "#{publish_count} articles. Check commit for details."
+    else
+      publish_message = @posts_to_publish[0]
+    end
+    "Auto-deployed. Published #{publish_message}"
+  end
+
+  def no_deployment_message
+    "Skipped auto-deploy since there were no posts to publish."
+  end
+
+  def notify(message)
+    `#{TERMINAL_NOTIFIER} -title 'TopTutoring' -message '#{message}'`
+  end
+
+  def shell_error
+    $CHILD_STATUS.exitstatus != 0
+  end
+end
+
+deployer = Deployer.new
+deployer.process

--- a/bin/auto_deploy_install.rb
+++ b/bin/auto_deploy_install.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+
+USER_DIRECTORY = `cd ~; pwd`.chomp.freeze
+PATH_TO_LAUNCH_LIB = (USER_DIRECTORY + "/Library/LaunchAgents").freeze
+PATH_TO_LAUNCH_PROGRAM = (PATH_TO_LAUNCH_LIB + "/auto_deploy.rb").freeze
+PATH_TO_LAUNCH_PLIST = (PATH_TO_LAUNCH_LIB + "/com.toptutoring.auto.deploy.plist").freeze
+PATH_TO_DIRECTORY = `pwd`.chomp.freeze
+PATH_TO_TTUTORING = PATH_TO_DIRECTORY.gsub("toptutoring", "ttutoring").freeze
+PATH_TO_DEPLOY_PROGRAM = (PATH_TO_DIRECTORY + "/bin/auto_deploy.rb").freeze
+PATH_TO_PLIST = (PATH_TO_DIRECTORY + "/bin/com.toptutoring.auto.deploy.plist").freeze
+
+def shell_success?
+  $?.exitstatus == 0
+end
+
+def rbenv_and_terminal?
+  system("which rbenv") && system("which terminal-notifier")
+end
+
+def install(original, new, text)
+  `cp #{original} #{new}`
+  if shell_success?
+    File.open(new, "w") do |file|
+      file.puts text
+    end
+    STDOUT.puts "Created file #{new}"
+  else
+    STDOUT.puts "Error while creating file #{new}"
+  end
+end
+
+def text_for_program
+  program_text = File.read(PATH_TO_DEPLOY_PROGRAM)
+  program_text.gsub!("INSTALL_TTUTORING_PATH", PATH_TO_TTUTORING)
+  program_text.gsub!("INSTALL_TERMINAL_NOTIFIER_PATH", USER_DIRECTORY + "/.rbenv/shims/terminal-notifier")
+end
+
+def text_for_plist
+  plist_text = File.read(PATH_TO_PLIST)
+  plist_text.gsub!("INSTALL_RUBY_PATH", `which ruby`.chomp)
+  plist_text.gsub!("INSTALL_SCRIPT_PATH", PATH_TO_LAUNCH_PROGRAM)
+end
+
+def load_program
+  `launchctl load #{PATH_TO_LAUNCH_PLIST}`
+  if shell_success?
+    STDOUT.puts "Installed successfully"
+  else
+    STDOUT.puts "Error while loading launch agent. Please check to see if #{PATH_TO_LAUNCH_PLIST} has been created successfully. Load manually by using the command: launchctl load #{PATH_TO_LAUNCH_PLIST}"
+  end
+end
+
+if File.exists?(PATH_TO_LAUNCH_PLIST)
+  STDOUT.puts "Already installed"
+elsif !rbenv_and_terminal?
+  STDOUT.puts "This program requires rbenv and terminal-notifier. Please install before continuing."
+else
+  install PATH_TO_DEPLOY_PROGRAM, PATH_TO_LAUNCH_PROGRAM, text_for_program
+  install PATH_TO_PLIST, PATH_TO_LAUNCH_PLIST, text_for_plist
+  load_program
+end

--- a/bin/auto_deploy_uninstall.rb
+++ b/bin/auto_deploy_uninstall.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+
+USER_DIRECTORY = `cd ~; pwd`.chomp.freeze
+PATH_TO_LAUNCH_LIB = (USER_DIRECTORY + "/Library/LaunchAgents").freeze
+PATH_TO_LAUNCH_PROGRAM = (PATH_TO_LAUNCH_LIB + "/auto_deploy.rb").freeze
+PATH_TO_LAUNCH_PLIST = (PATH_TO_LAUNCH_LIB + "/com.toptutoring.auto.deploy.plist").freeze
+
+def display(message)
+  STDOUT.puts message
+end
+
+def shell_success?
+  $?.exitstatus == 0
+end
+
+def installed?
+  File.exists?(PATH_TO_LAUNCH_PLIST) ||
+    File.exists?(PATH_TO_LAUNCH_PROGRAM) ||
+    loaded?
+end
+
+def loaded?
+  !`launchctl list | grep com\.toptutoring\.auto\.deploy`.empty?
+end
+
+def unload_message
+  if shell_success? && !loaded?
+    display "Successfully unloaded #{PATH_TO_LAUNCH_PLIST}."
+  else
+    display "Failure! Was unable to unload #{PATH_TO_LAUNCH_PLIST} from launchctl. Please check manually."
+  end
+end
+
+def unload_program
+  if loaded?
+    display "Proceeding to unload program from launchctl."
+    `launchctl unload #{PATH_TO_LAUNCH_PLIST}`
+    unload_message
+  else
+    display "Program not loaded. Skipping step."
+  end
+end
+
+def remove_files
+  display "Proceeding to remove files."
+  `rm #{PATH_TO_LAUNCH_PLIST} #{PATH_TO_LAUNCH_PROGRAM}`
+  if shell_success?
+    display "Successfully removed #{PATH_TO_LAUNCH_PLIST} and #{PATH_TO_LAUNCH_PROGRAM}"
+  else
+    display "Failure! Unable to remove #{PATH_TO_LAUNCH_PLIST} and #{PATH_TO_LAUNCH_PROGRAM}. Please check the #{PATH_TO_LAUNCH_LIB} directory to see if these files are present."
+  end
+end
+
+if installed?
+  unload_program
+  remove_files
+else
+  display "Nothing to uninstall."
+end
+
+display "Uninstall auto_deploy has finished running."

--- a/bin/com.toptutoring.auto.deploy.plist
+++ b/bin/com.toptutoring.auto.deploy.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+        <string>com.toptutoring.auto.deploy</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>INSTALL_RUBY_PATH</string>
+      <string>INSTALL_SCRIPT_PATH</string>
+    </array>
+    <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false />
+        </dict>
+    <key>StartCalendarInterval</key>
+        <dict>
+          <key>Hour</key>
+          <integer>3</integer>
+          <key>Minute</key>
+          <integer>0</integer>
+        </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Also adds install and uninstall scripts. Requires rbenv and terminal-notifier.

To install, simply run `bin/auto_deploy_install.rb` from the toptutoring directory.
To uninstall, run `bin/auto_deploy_uninstall.rb`.

The script is smart enough to detect when it is appropriate to push an empty commit to publish future dated posts.
![image](https://user-images.githubusercontent.com/24426214/31536065-333695a6-afb2-11e7-82de-01932077baed.png)

It notifies the user and cancels the deployment if the user is working on the branch.
![image](https://user-images.githubusercontent.com/24426214/31536115-5c64a080-afb2-11e7-993a-ea79e3968235.png)

It notifies the user of the deployment. If only one post was published, it states the name of the file published. If there were more than one, it will list the total number of posts published. The commit message will list all the files that were published.
![image](https://user-images.githubusercontent.com/24426214/31560300-9ea08346-b008-11e7-9ec7-1fcf123a4059.png)

If the user was on a branch other than gh-pages, the script will return to the branch before finishing.
