### PR TITLE
No show for Invoices are worth 0 hours

### DIFF
--- a/app/assets/javascripts/invoice_session.js
+++ b/app/assets/javascripts/invoice_session.js
@@ -9,8 +9,8 @@ $(function() {
       text : "24 hour Cancellation (No hours are charged)"
     }));
     $('.hours').append($('<option>', {
-      value: 0.5,
-      text : "No show (Client will be charged for 30 mins)"
+      value: 'no_show',
+      text : "No show"
     }));
     create_hour_options(5);
   }

--- a/app/controllers/tutors/invoices_controller.rb
+++ b/app/controllers/tutors/invoices_controller.rb
@@ -7,6 +7,7 @@ module Tutors
     end
 
     def create
+      update_no_show_params if params[:invoice][:hours] == 'no_show'
       create_invoice
       adjust_balances_and_save_records
       set_flash_messages
@@ -24,6 +25,11 @@ module Tutors
 
     private
 
+    def update_no_show_params
+      params[:invoice][:hours] = 0
+      @note = 'No Show'
+    end
+
     def create_invoice
       @by_tutor = params[:invoice][:submitter_type] == 'by_tutor'
       if @by_tutor
@@ -40,7 +46,7 @@ module Tutors
             .merge(submitter: current_user, status: "pending",
                    submitter_pay: submitter_pay, client: @client,
                    amount: client_charge, hourly_rate: hourly_rate,
-                   engagement: @engagement, subject: subject)
+                   engagement: @engagement, subject: subject, note: @note)
     end
 
     def subject
@@ -90,7 +96,7 @@ module Tutors
       elsif @adjuster.client_low_balance?
         flash.alert = "Your invoice has been created. However, your client is running low on their balance. Please consider making a suggestion to your client to add to their balance before scheduling any more sessions."
       else
-        flash.notice = @by_tutor ? "Invoice has been created." : "Timesheet has been created"
+        flash.notice = @by_tutor ? "Invoice has been created." : "Timesheet has been created."
       end
     end
   end

--- a/app/helpers/invoice_helper.rb
+++ b/app/helpers/invoice_helper.rb
@@ -15,6 +15,13 @@ module InvoiceHelper
     end
   end
 
+  def invoice_note_label(invoice)
+    return unless invoice.note
+    content_tag(:p, class: "label label-outline label-danger") do
+      invoice.note
+    end
+  end
+
   private
 
   def authorized_to_pay?(invoices, type)

--- a/app/views/admin/invoices/_invoice_table.html.erb
+++ b/app/views/admin/invoices/_invoice_table.html.erb
@@ -18,7 +18,11 @@
     <tbody>
       <% invoices.order(:submitter_id).each do |invoice| %>
         <tr>
-          <td><%= invoice.id %></td>
+          <td>
+            <%= invoice.id %>
+            <br />
+            <%= invoice_note_label(invoice) %>
+        </td>
           <td><%= name = invoice.submitter.name %></td>
           <td><%= invoice.created_at.strftime("%-m/%-e/%y") %></td>
           <td><%= invoice.engagement.academic_type %></td>

--- a/db/migrate/20171115183842_add_notes_to_invoice.rb
+++ b/db/migrate/20171115183842_add_notes_to_invoice.rb
@@ -1,0 +1,5 @@
+class AddNotesToInvoice < ActiveRecord::Migration[5.1]
+  def change
+    add_column :invoices, :note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171017182521) do
+ActiveRecord::Schema.define(version: 20171115183842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 20171017182521) do
     t.integer "submitter_pay_cents"
     t.integer "amount_cents"
     t.integer "submitter_type", default: 0
+    t.string "note"
     t.index ["client_id"], name: "index_invoices_on_client_id"
     t.index ["engagement_id"], name: "index_invoices_on_engagement_id"
     t.index ["submitter_id"], name: "index_invoices_on_submitter_id"

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 feature 'Invoices Index' do
   let(:tutor) { FactoryGirl.create(:tutor_user) }
@@ -32,5 +32,14 @@ feature 'Invoices Index' do
     expect(page).to have_content(invoice.description)
     expect(page).to have_content(invoice.status)
     expect(page).to have_content("$15.00")
-    end
+    expect(page).not_to have_content('No Show')
+  end
+
+  scenario 'when invoice has a note' do
+    invoice.update(note: 'No Show')
+    sign_in(admin)
+    visit admin_invoices_path
+
+    expect(page).to have_content('No Show')
+  end
 end

--- a/spec/features/invoices/create_spec.rb
+++ b/spec/features/invoices/create_spec.rb
@@ -38,6 +38,27 @@ feature 'Create Invoice', js: true do
     sign_out
   end
 
+    scenario 'creates invoice as no show' do
+      set_roles
+      student
+      engagement
+
+      sign_in(tutor)
+
+      find('.hours').find(:xpath, 'option[2]').select_option
+      fill_in "invoice[subject]", with: "Mathmatics"
+      fill_in "Description", with: "no show"
+
+      click_on "Create Invoice"
+
+      expect(page).to have_content("Invoice has been created.")
+      expect(tutor.reload.outstanding_balance).to eq(0)
+      expect(client.reload.academic_credit).to eq(50)
+      expect(Invoice.last.note).to eq("No Show")
+
+      sign_out
+    end
+
   scenario 'low balance warning' do
     set_roles
     student


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/0a9lhcQG/169-changing-drop-down-selection-for-invoicing-for-student-cancellations)
[Trello Ticket 2](https://trello.com/c/sQllQOhn/161-when-tutor-invoices-no-show-it-should-show-up-as-no-show-in-director-admin-view-under-engagements)

Charge for no shows are being handled manually. However, the code was showing the user that 0.5 hours will be charged. This was updated so no mention of payment is listed. Description is updated to have "NO SHOW: " at the beginning so it is apparent to the director/admin that the invoice is for a no show and not for a 24 hour cancellation (both with have 0 hours listed).

Snapshot of dash
![image](https://user-images.githubusercontent.com/24426214/32923956-2cc8eeb4-caef-11e7-9613-aaa70cd44c1e.png)
