### PR TITLE
Updates CreditUpdater to adjust amount and pay

### DIFF
--- a/app/services/credit_updater.rb
+++ b/app/services/credit_updater.rb
@@ -56,7 +56,7 @@ class CreditUpdater
       else
         # Don't do anything if hours did not change
       end
-      @invoice.update(update_params)
+      update_invoice(update_params)
     end
   end
 
@@ -97,5 +97,22 @@ class CreditUpdater
   def subtract_from_submitter_balance(hours)
     @submitter.outstanding_balance -= hours
     @submitter.save!
+  end
+
+  def update_invoice(update_params)
+    @invoice.update(update_params)
+    rate = @submitter.tutor_account.contract.hourly_rate
+    @invoice.submitter_pay = @invoice.hours * rate
+    @invoice.amount = updated_amount if @client
+    @invoice.save!
+  end
+
+  def updated_amount
+    if @engagement.academic?
+      @invoice.hours * @client.academic_rate
+    elsif @engagement.test_prep?
+      @invoice.hours * @client.test_prep_rate
+    else
+    end
   end
 end

--- a/spec/services/credit_updater_spec.rb
+++ b/spec/services/credit_updater_spec.rb
@@ -57,6 +57,24 @@ describe CreditUpdater do
         expect { subject.update_existing_invoice(new_params) }
           .to change { submitter.reload.outstanding_balance }.by(3)
       end
+
+      it "Updates submitter_pay" do
+        subject = CreditUpdater.new(invoice)
+        new_hours = new_params["hours"].to_f
+        old_hours = invoice.hours # 2 hours
+        difference = new_hours - old_hours
+        expect { subject.update_existing_invoice(new_params) }
+          .to change { invoice.reload.submitter_pay }.by(submitter.tutor_account.contract.hourly_rate * 3)
+      end
+
+      it "Updates amount charged to client" do
+        subject = CreditUpdater.new(invoice)
+        new_hours = new_params["hours"].to_f
+        old_hours = invoice.hours # 2 hours
+        difference = new_hours - old_hours
+        expect { subject.update_existing_invoice(new_params) }
+          .to change { invoice.reload.amount }.by(client.test_prep_rate * 3)
+      end
     end
 
     context "when the new invoice is lower" do


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/vXx8ZJOF/183-change-tutor-pay-amount-client-charge)

The CreditUpdate service wasn't updating the submitter pay and amount when the invoice was updated. This adds that code while securing it with tests.