### PR TITLE
Removes separation of pending/processed invoices for clients

### DIFF
--- a/app/controllers/clients/invoices_controller.rb
+++ b/app/controllers/clients/invoices_controller.rb
@@ -10,6 +10,8 @@ module Clients
       ] }
       @invoices = current_user.client_account
                               .invoices
+                              .where.not(status: "denied")
+                              .order(created_at: :desc)
                               .includes(include_hash)
     end
   end

--- a/app/views/clients/invoices/index.html.erb
+++ b/app/views/clients/invoices/index.html.erb
@@ -1,4 +1,3 @@
 <div class="page-content container-fluid">
-  <%= render "invoices/invoice_table_layout", type: "Pending", invoices: @invoices.pending %>
-  <%= render "invoices/invoice_table_layout", type: "Processed", invoices: @invoices.not_pending.where.not(status: "denied") %>
+  <%= render "invoices/invoice_table_layout", type: nil, invoices: @invoices %>
 </div>

--- a/spec/features/clients/invoices/index_spec.rb
+++ b/spec/features/clients/invoices/index_spec.rb
@@ -14,8 +14,6 @@ feature "Clients Invoices Index" do
     visit clients_invoices_path
 
     expect(page).to have_content("Invoices")
-    expect(page).to have_content("Pending")
-    expect(page).to have_content("Processed")
     expect(page).to have_content("Tutor")
     expect(page).to have_content("Student")
     expect(page).to have_content("Subject")


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/OEQhVmDB/190-clients-invoices-view-should-not-have-processed-pending-separation)

Also orders the invoices from the newest to oldest.

![image](https://user-images.githubusercontent.com/24426214/34009598-5e7b8f7c-e0be-11e7-8d7a-a97cee2878c2.png)
