### PR TITLE
Data migration for payment error

### DIFF
--- a/app/services/mass_payment_service.rb
+++ b/app/services/mass_payment_service.rb
@@ -145,8 +145,8 @@ class MassPaymentService
     @payouts.each do |payout|
       auth_id = payout.payee.auth_uid
       payout_item = items.find { |item| auth_id == item[:metadata][:auth_uid] }
-      payout.status = "processing"
-      payout.dwolla_transfer_url = payout_item[:_links][:transfer][:href]
+      payout.status = "paid"
+      payout.dwolla_transfer_url = payout_item[:_links][:transfer][:href] unless payout_item.nil?
       payout.save
     end
   end

--- a/db/migrate/20180116072145_update_paid_invoices.rb
+++ b/db/migrate/20180116072145_update_paid_invoices.rb
@@ -1,0 +1,36 @@
+class UpdatePaidInvoices < ActiveRecord::Migration[5.1]
+  def up
+    user = User.find_by(id: 90, name: "Ki Park", email: "kidonpark828@berkeley.edu")
+    return unless user
+    paid_invoices = user.invoices.where(status: "processing")
+    create_payout(user, paid_invoices)
+    update_balances(user, paid_invoices.sum(:hours))
+    update_invoices(paid_invoices)
+  end
+
+  private 
+
+  def create_payout(user, paid_invoices)
+    total_paid = paid_invoices.sum(:submitter_pay_cents)
+    Payout.create!(receiving_account: user.tutor_account,
+                   amount_cents: total_paid,
+                   approver: User.admin, status: "paid",
+                   destination: user.auth_uid,
+                   funding_source: FundingSource.last.funding_source_id,
+                   description: "Payment for invoices: #{paid_invoices.ids.join(", ")}.")
+    STDOUT.puts "Created payout for invoices ##{paid_invoices.ids}."
+  end
+
+  def update_balances(user, hours)
+    user.outstanding_balance -= hours
+    user.save!
+    STDOUT.puts "Updated user ##{user.id}'s outstanding_balance to #{user.outstanding_balance}."
+  end
+
+  def update_invoices(paid_invoices)
+    paid_invoices.find_each do |invoice|
+      invoice.update!(status: "paid")
+      STDOUT.puts "Updated invoice ##{invoice.id} to paid."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180115070830) do
+ActiveRecord::Schema.define(version: 20180116072145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
User #90 was paid but because of dwolla error, payout was not recorded and balances adjusted. This data migration fixes the data error, and also does a quick fix so the error does not occur again. However, a more complete fix will be handled in [pr-222](https://github.com/plexmate/toptutoring/pull/221).