### PR TITLE
Add notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,20 @@
+class NotificationsController < ApplicationController
+  before_action :require_login
+
+  def update
+    @notice = Notification.find(params[:id])
+    @notice.update(read: true)
+    @count = current_user.notifications.unread.count
+  end
+
+  def mark_all
+    notifications = current_user.notifications.unread
+    notifications.update_all(read: true)
+  end
+
+  def destroy
+    Notification.find(params[:id]).destroy!
+    flash.alert = "Notification has been deleted."
+    redirect_to action: :index
+  end
+end

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,0 +1,49 @@
+module NotificationHelper
+  def notification_count(user)
+    count = user.notifications.unread.count
+    return if count < 1
+    tag.span(count, class: "badge bg-danger")
+  end
+
+  def user_notifications_list(user)
+    if user.notifications.unread.any?
+      capture do
+        user.notifications.unread.each do |notice|
+          concat notification_list_item(notice)
+        end
+      end
+    else
+      render "notifications/no_messages"
+    end
+  end
+
+  private
+
+  def notification_list_item(notice)
+    tag.li class: "media", id: "notification_#{notice.id}" do
+      link_to notification_path(notice), method: :patch, remote: true do
+        concat icon(notice)
+        concat message(notice)
+      end
+    end
+  end
+
+  def icon(notice)
+    icon_class = "media-object mo-md img-circle text-center bg-success"
+    icon_type = case notice.message_type
+                when "invoice" then " ion-cash"
+                when "alert" then " ion-alert"
+                else " ion-ios-email"
+                end
+    tag.div class: "media-left" do
+      concat tag.i class: icon_class + icon_type
+    end
+  end
+
+  def message(notice)
+    tag.div class: "media-body" do
+      concat tag.h5 notice.title, class: "media-heading"
+      concat tag.p notice.message, class: "text-muted mb-0"
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,6 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  scope :unread, -> { where(read: false) }
+
+  enum message_type: { notice: "notice", invoice: "invoice", alert: "alert" }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   has_one :signup, dependent: :destroy
   has_one :stripe_account
   accepts_nested_attributes_for :signup
+  has_many :notifications
   has_many :students, class_name: "User", foreign_key: "client_id"
   has_one :student_account, dependent: :destroy
   has_one :client_account, dependent: :destroy

--- a/app/views/application/_user_header.html.erb
+++ b/app/views/application/_user_header.html.erb
@@ -15,6 +15,37 @@ FS.identify('<%= current_user.id %>', {
   
   <div class="right-side-header">
     <ul class="notification-bar list-inline pull-right">
+      <% if current_user.has_role?("admin") %>
+        <li class="dropdown">
+          <a id="dropdownMenu1" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle header-icon bubble">
+            <i class="fs-24 icon ion-ios-email-outline" id="notification_count"><%= notification_count(current_user) %></i>
+          </a>
+          <div aria-labelledby="dropdownMenu1" class="dropdown-menu dropdown-menu-right dm-medium fadeInUp animated" style="animation-duration: 0.2s; animation-delay: 0s; animation-timing-function: linear; animation-iteration-count: 1;">
+            <h5 class="dropdown-header">Your Notifications</h5>
+            <ul data-mcs-theme="minimal-dark" class="media-list mCustomScrollbar _mCS_2 mCS-autoHide" style="position: relative; overflow: visible;">
+              <div id="mCSB_2" class="mCustomScrollBox mCS-minimal-dark mCSB_vertical mCSB_outside" style="max-height: 240px;" tabindex="0">
+                <div id="mCSB_2_container" class="mCSB_container" style="position: relative; top: 0px; left: 0px;" dir="ltr">
+                  <div id="notification_list">
+                    <%= user_notifications_list(current_user) %>
+                  </div>
+                </div>
+              </div>
+              <div id="mCSB_2_scrollbar_vertical" class="mCSB_scrollTools mCSB_2_scrollbar mCS-minimal-dark mCSB_scrollTools_vertical" style="display: block;">
+                <div class="mCSB_draggerContainer">
+                  <div id="mCSB_2_dragger_vertical" class="mCSB_dragger" style="position: absolute; min-height: 50px; top: 0px; display: block; height: 144px; max-height: 206px;" oncontextmenu="return false;">
+                    <div class="mCSB_dragger_bar" style="line-height: 50px;">
+                    </div>
+                  </div>
+                  <div class="mCSB_draggerRail">
+                  </div>
+                </div>
+              </div>
+            </ul>
+            <div class="dropdown-footer"><%= link_to "Mark all as read", mark_all_notifications_path, method: :post, remote: true, class: "text-muted" %></div>
+          </div>
+        </li>
+      <% end %>
+
       <li class="dropdown">
         <a id="dropdownMenu2" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle header-icon">
           <div class="media mt-0">

--- a/app/views/notifications/_no_messages.html.erb
+++ b/app/views/notifications/_no_messages.html.erb
@@ -1,0 +1,5 @@
+<li class="media">
+  <div class="media-body">
+    <h5 class="media-heading">You have no unread notifications</h5>
+  </div>
+</li>

--- a/app/views/notifications/mark_all.js.erb
+++ b/app/views/notifications/mark_all.js.erb
@@ -1,0 +1,4 @@
+var count = document.getElementById("notification_count").children[0]
+count.innerHTML = ""
+var list = document.getElementById("notification_list")
+list.innerHTML = "<%= escape_javascript(render("no_messages")) %>"

--- a/app/views/notifications/update.js.erb
+++ b/app/views/notifications/update.js.erb
@@ -1,0 +1,10 @@
+var notice = document.getElementById("<%= "notification_#{@notice.id}" %>")
+notice.parentNode.removeChild(notice)
+var count = document.getElementById("notification_count").children[0]
+  <% if @count >0 %>
+    count.innerText = <%= @count %>
+<% else %>
+    count.innerHTML = ""
+<% end %>
+
+console.log("Success!")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,12 @@ Rails.application.routes.draw do
       resource :masquerade, only: :destroy
     end
 
+    resources :notifications do
+      collection do
+        post "mark_all"
+      end
+    end
+
     resource :profile, only: [:edit, :show, :update]
 
     constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("admin") } do

--- a/db/migrate/20180119010903_create_notifications.rb
+++ b/db/migrate/20180119010903_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notifications do |t|
+      t.string :message_type
+      t.string :title
+      t.string :message
+      t.boolean :read, default: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -189,6 +189,17 @@ ActiveRecord::Schema.define(version: 20180322180423) do
     t.index ["submitter_id"], name: "index_invoices_on_submitter_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.string "message_type"
+    t.string "title"
+    t.string "message"
+    t.boolean "read", default: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "payments", id: :serial, force: :cascade do |t|
     t.integer "amount_cents"
     t.string "description"

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe NotificationsController, type: :controller do
+  subject = NotificationsController
+  let(:tutor) { FactoryBot.create(:tutor_user) }
+  let!(:notification) { FactoryBot.create(:notification, user: tutor) }
+
+  before(:each) do
+    sign_in_as tutor
+  end
+
+  describe "#mark_all" do
+    it "marks all unread notifications to read" do
+      post :mark_all
+
+      expect(flash.notice).to eq "Marked 1 notification as read."
+      expect(notification.reload.read).to be true
+    end
+
+    it "does nothing if there are no unread notifications" do
+      notification.update(read: true)
+      post :mark_all
+
+      expect(flash.alert).to eq "No notifications to mark as read."
+      expect(notification.reload.read).to be true
+    end
+  end
+
+  describe "#show" do
+    it "marks notifications as read" do
+      get :show, params: { id: notification.id }
+
+      expect(notification.reload.read).to be true
+    end
+  end
+end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :notification do
+    message_type "notice"
+    title "A Notfiication"
+    message "You received a notification"
+    user { FactoryBot.create(:client_user) }
+  end
+end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "User interacts with notifications" do
+  let(:tutor) { FactoryBot.create(:tutor_user) }
+  let!(:notification) { FactoryBot.create(:notification, user: tutor) }
+
+  scenario "visits index" do
+    sign_in tutor
+    visit notifications_path
+    expect(page).to have_content(notification.message)
+    expect(page).to have_content(notification.title)
+    expect(page).to have_link("Mark as read")
+    expect(page).to have_link("Delete")
+  end
+
+  scenario "marks notification as read" do
+    sign_in tutor
+    visit notifications_path
+    click_on "Mark as read"
+
+    expect(page).to have_content("Notification has been marked as read.")
+    expect(page).not_to have_link("Mark as read")
+  end
+
+  scenario "visits show" do
+    sign_in tutor
+    visit notification_path(notification)
+
+    delete_link = find_link(href: notification_path(notification))
+    expect(page).to have_content(notification.message)
+    expect(page).to have_content(notification.title)
+    expect(delete_link.matches_selector?("a[data-method='delete']")).to be true
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  it { should belong_to(:user) }
+end


### PR DESCRIPTION
Adds a feature to allow notifications to be sent to users. 
This will allow us to notify users of invoices made, invoices paid, invoices canceled, low balances, etc.
As more features are added, this feature will be very useful to build upon.

Index (notice the top right where the notification alert is placed)
![image](https://user-images.githubusercontent.com/24426214/35309748-c8d8260a-0062-11e8-848f-8078fa747065.png)

Click the alert and a drop down pops up
![image](https://user-images.githubusercontent.com/24426214/35309751-cccd2828-0062-11e8-8beb-a55c7f44b836.png)

Show page. Automatically marks as read and has trash link.
![image](https://user-images.githubusercontent.com/24426214/35309761-d3dd0d90-0062-11e8-90ed-287d6ebd4fed.png)

![image](https://user-images.githubusercontent.com/24426214/35309769-e27134bc-0062-11e8-8770-ce18907684e2.png)

![image](https://user-images.githubusercontent.com/24426214/35309774-e58c8cb4-0062-11e8-90d5-affa96c85dba.png)
