### PR TITLE
Removes metadata from Dwolla payment

### DIFF
--- a/app/services/dwolla_payment_service.rb
+++ b/app/services/dwolla_payment_service.rb
@@ -30,7 +30,7 @@ class DwollaPaymentService
           value: payout.amount
         },
         metadata: {
-          concept: payout.description
+          description: "Top Tutoring payment for invoice ##{payout.invoices.ids}."
         }
       }
     end


### PR DESCRIPTION
An unnecessary metadata field was being added to dwolla payments. Removed.