### PR TITLE
Fixes error when using saved card

### DIFF
--- a/app/assets/javascripts/client_payment_stripe.js
+++ b/app/assets/javascripts/client_payment_stripe.js
@@ -40,8 +40,8 @@ $(function() {
 
     form.addEventListener('submit', function(event) {
       $('input[type=submit]').attr('disabled', true);
-      event.preventDefault();
       if (document.getElementById("use_new_card").checked) {
+        event.preventDefault();
         var options = { name: document.getElementById('card_holder_name').value,
           address_line1: document.getElementById('card_address').value,
           address_line2: document.getElementById('card_unit_number').value,

--- a/app/views/clients/payments/_payment_form.html.erb
+++ b/app/views/clients/payments/_payment_form.html.erb
@@ -89,6 +89,7 @@
                 <%= select_tag :card_id, options_for_select(@account.card_options, @account.customer.default_source), class: "form-control input-lg" %>
               <% else %>
                 <p class="form-control input-lg"><%= @account.default_display %></p>
+                <%= hidden_field_tag :card_id, @account.customer.default_source %>
               <% end %>
             </div>
             <div class="mb-15">


### PR DESCRIPTION
Card id was not being sent as a parameter which was causing errors. Also, the prevent default javascript was placed elsewhere so form can be submitted when using a saved card.