### PR TITLE
Adds scroll with css for sidebar

### DIFF
--- a/app/assets/stylesheets/application_adjustments.scss
+++ b/app/assets/stylesheets/application_adjustments.scss
@@ -14,6 +14,9 @@ header li a, .dropdown-menu li > a {
 
 // Sidebar Styles
 
+.main-sidebar {
+  overflow: auto;
+}
 .menu-profile-icon {
   width: 56px;
   height: 56px;


### PR DESCRIPTION
This so that if the scroll bar generated by js doesn't work, the sidebar will still be able to be scrolled.