### PR TITLE
Set asset host to app subdomain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
-  # config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
+  config.action_controller.asset_host = ENV.fetch("APPLICATION_HOST")
   config.log_level = :debug
   config.log_tags = [ :request_id ]
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
Assets aren't being served because top level domain is being served by ttutoring. This is causing a failure. This explicitly sets the asset host in production so the assets are served by our rails server.

