### PR TITLE
Adds route to test migration on prod

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,7 @@ Rails.application.routes.draw do
           get "/disable" => "engagements#disable"
         end
       end
+      get "/test-migration", to: "pages#home"
     end
 
     constraints Clearance::Constraints::SignedIn.new { |user| user.has_role?("tutor") } do


### PR DESCRIPTION
Allows admin and directors to be able to view ttutoring migration on rails server by visiting the "/test-migration" path on the "app" subdomain.