### PR TITLE
Adds dynamic page titles for www

### DIFF
--- a/app/controllers/pages/blog/categories_controller.rb
+++ b/app/controllers/pages/blog/categories_controller.rb
@@ -11,6 +11,7 @@ module Pages
         @posts = cat.blog_posts.published
                     .order(:publish_date)
                     .paginate(page: params[:page], per_page: 5)
+        @page_title = "Top Tutoring | Blog | #{cat.name}"
         render "pages/blog_posts/index"
       end
 

--- a/app/controllers/pages/blog_posts_controller.rb
+++ b/app/controllers/pages/blog_posts_controller.rb
@@ -5,10 +5,12 @@ module Pages
       @posts = BlogPost.published
                        .order(publish_date: :desc)
                        .paginate(page: params[:page], per_page: 5)
+      @page_title = "Top Tutoring | Blog"
     end
 
     def show
       @post = BlogPost.published.find_by!(slug: slug)
+      @page_title = @post.title
     end
 
     private

--- a/app/controllers/pages/tutors_controller.rb
+++ b/app/controllers/pages/tutors_controller.rb
@@ -3,6 +3,7 @@ module Pages
     layout "authentication"
     def index
       @tutor_accounts = TutorAccount.published.limit(9).includes(:user)
+      @page_title = "Top Tutoring | Our Top Tutors"
     end
 
     def show
@@ -10,6 +11,7 @@ module Pages
                    .where(tutor_accounts: { publish: true })
                    .find_by(first_name: name_param)
       not_found unless @tutor
+      @page_title = "Top Tutoring | Meet #{@tutor.first_name}"
     end
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,8 @@ module ApplicationHelper
   def current_year
     CURRENT_YEAR || Date.current.year
   end
+
+  def page_title(page_title = "Top Tutoring")
+    content_for :page_title, page_title
+  end
 end

--- a/app/views/layouts/authentication.html.erb
+++ b/app/views/layouts/authentication.html.erb
@@ -11,7 +11,7 @@
     %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <%= yield :meta_tags %>
-    <title>Top Tutoring</title>
+    <title><%= yield :page_title %></title>
     <!-- Google Tag Manager -->
     <% if (ENV["DWOLLA_ENVIRONMENT"] == "production") && Rails.env.production? %>
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/app/views/pages/blog_posts/_blog_layout.html.erb
+++ b/app/views/pages/blog_posts/_blog_layout.html.erb
@@ -1,3 +1,4 @@
+<% page_title(@page_title) %>
 <section>
   <div class="container">
     <div class="row">

--- a/app/views/pages/tutors/index.html.erb
+++ b/app/views/pages/tutors/index.html.erb
@@ -1,3 +1,4 @@
+<% page_title(@page_title) %>
 <section class="bg-secondary">
   <div class="container">
     <div class="row">

--- a/app/views/pages/tutors/show.html.erb
+++ b/app/views/pages/tutors/show.html.erb
@@ -1,39 +1,40 @@
-  <section>
-    <div class="container">
-      <div class="feed-item mb96 mb-xs-48">
+<% page_title(@page_title) %>
+<section>
+  <div class="container">
+    <div class="feed-item mb96 mb-xs-48">
 
-        <div class="row mb16 mb-xs-0">
-          <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 text-center">
-            <h3 class="uppercase color-primary mb40 mb-xs-24">meet our top tutors</h3>
-            <h3><%= @tutor.first_name %></h3>
-            <% if @tutor.tutor_account.test_scores.where.not(badge: nil).any? %>
-              <i class="icon ti-medall test-badge test-badge-gold" data-toggle="tooltip" data-placement="left" data-original-title="This tutor is a top performer in <%= @tutor.tutor_account.test_scores.where.not(badge: nil).map { |score| score.subject.name }.join(", ") %>"></i>
+      <div class="row mb16 mb-xs-0">
+        <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 text-center">
+          <h3 class="uppercase color-primary mb40 mb-xs-24">meet our top tutors</h3>
+          <h3><%= @tutor.first_name %></h3>
+          <% if @tutor.tutor_account.test_scores.where.not(badge: nil).any? %>
+            <i class="icon ti-medall test-badge test-badge-gold" data-toggle="tooltip" data-placement="left" data-original-title="This tutor is a top performer in <%= @tutor.tutor_account.test_scores.where.not(badge: nil).map { |score| score.subject.name }.join(", ") %>"></i>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="row mb32 mb-xs-16">
+        <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
+          <div class="text-center">
+            <% unless @tutor.tutor_account.profile_picture.file.nil? %>
+              <%= image_tag @tutor.tutor_account.profile_picture.url, class: "mb32 mb-xs-16 cast-shadow img-profile", alt: @tutor.full_name %>
             <% end %>
           </div>
-        </div>
-
-        <div class="row mb32 mb-xs-16">
-          <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
-            <div class="text-center">
-              <% unless @tutor.tutor_account.profile_picture.file.nil? %>
-                <%= image_tag @tutor.tutor_account.profile_picture.url, class: "mb32 mb-xs-16 cast-shadow img-profile", alt: @tutor.full_name %>
-              <% end %>
-            </div>
-            <%= raw @tutor.tutor_account.description.try(:gsub, "\r\n", "<br />") %>
-          </div>
-        </div>
-
-      </div>
-    </div>
-  </section>
-
-  <section class="bg-primary">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-12 text-center">
-          <h3 class="mb0 inline-block p32 p0-xs">Ready to start your first tutoring session?</h3>
-          <%= link_to "Sign Up", sign_up_url(subdomain: "app"), class: "btn btn-lg btn-white mb8 mt-xs-24" %>
+          <%= raw @tutor.tutor_account.description.try(:gsub, "\r\n", "<br />") %>
         </div>
       </div>
+
     </div>
-  </section>
+  </div>
+</section>
+
+<section class="bg-primary">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-12 text-center">
+        <h3 class="mb0 inline-block p32 p0-xs">Ready to start your first tutoring session?</h3>
+        <%= link_to "Sign Up", sign_up_url(subdomain: "app"), class: "btn btn-lg btn-white mb8 mt-xs-24" %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/www/pages/about_us.html.erb
+++ b/app/views/www/pages/about_us.html.erb
@@ -1,3 +1,4 @@
+<% page_title("Top Tutoring | About Us") %>
 <section class="image-square right">
   <div class="col-md-6 image">
     <div class="background-image-holder">

--- a/app/views/www/pages/careers.html.erb
+++ b/app/views/www/pages/careers.html.erb
@@ -1,3 +1,4 @@
+<% page_title("Top Tutoring | Careers") %>
 <h3 class="career-header"><%= t('www.careers.header') %></h1>
 <section class="image-square left">
   <div class="col-md-6 image">

--- a/app/views/www/pages/contact.html.erb
+++ b/app/views/www/pages/contact.html.erb
@@ -1,3 +1,4 @@
+<% page_title("Top Tutoring | Contact") %>
 <section>
   <div class="container">
     <div class="row">

--- a/app/views/www/pages/home.html.erb
+++ b/app/views/www/pages/home.html.erb
@@ -1,3 +1,4 @@
+<% page_title("Top Tutoring") %>
 <section class="image-slider slider-all-controls parallax controls-inside pt0 pb0">
   <ul class="slides">
     <li class="overlay image-bg pt240 pb240 pt-xs-120 pb-xs-120">

--- a/app/views/www/pages/how_it_works.html.erb
+++ b/app/views/www/pages/how_it_works.html.erb
@@ -1,3 +1,4 @@
+<% page_title("Top Tutoring | How It Works") %>
 <section>
   <div class="container">
     <div class="row">


### PR DESCRIPTION
[Trello](https://trello.com/c/21HsV640/267-make-blog-page-category-title-more-seo-friendly)

All www pages now have dynamic title.
Blog pages do not have "Top tutoring" prepended to the title.
![image](https://user-images.githubusercontent.com/24426214/38519221-ef8cd67a-3bf3-11e8-8230-4268a2bfa126.png)
