### PR TITLE
Removes signup from nav bar

### DIFF
--- a/app/views/application/_authentication_header.html.erb
+++ b/app/views/application/_authentication_header.html.erb
@@ -25,9 +25,6 @@
             <%= link_to "Top Tutors", root_url(subdomain: nil) + "top-tutors", class: "page-link logo-dark" %>
           </li>
           <li>
-            <%= link_to "SAT & ACT", root_url(subdomain: nil) + "sat-act-prep", class: "page-link logo-dark" %>
-          </li>
-          <li>
             <%= link_to "Blog", root_url(subdomain: nil) + "blog", class: "page-link logo-dark" %>
           </li>
           <li>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -4,28 +4,28 @@
       <span class="footer-left">
         <ul class="col-md-12 col-xs-6">
           <li>
-            <%= link_to "Home", root_url(subdomain: nil), class: "uppercase mb16 face-on-hover footer-link first" %>
+            <%= link_to "Home", root_url(subdomain: nil), class: "uppercase mb16 face-on-hover first" %>
           </li>
           <li>
-            <%= link_to "Find a tutor", client_sign_up_url(subdomain: "app"), class: "uppercase mb16 fade-on-hover footer-link" %>
+            <%= link_to "Find a tutor", client_sign_up_url(subdomain: "app"), class: "uppercase mb16 fade-on-hover" %>
           </li>
           <li>
-            <%= link_to "Careers", root_url(subdomain: nil) + "careers", class: "uppercase mb16 face-on-hover footer-link" %>
+            <%= link_to "Careers", root_url(subdomain: nil) + "careers", class: "uppercase mb16 face-on-hover" %>
           </li>
           <li>
-            <%= link_to "Blog", root_url(subdomain: nil) + "blog", class: "uppercase mb16 face-on-hover footer-link" %>
+            <%= link_to "Blog", root_url(subdomain: nil) + "blog", class: "uppercase mb16 face-on-hover" %>
           </li>
           <li>
-            <%= link_to "Our Tutors", root_url(subdomain: nil) + "top-tutors", class: "uppercase mb16 face-on-hover footer-link" %>
+            <%= link_to "Our Tutors", root_url(subdomain: nil) + "top-tutors", class: "uppercase mb16 face-on-hover" %>
           </li>
           <li>
-            <%= link_to "SAT & ACT", root_url(subdomain: nil) + "sat-act-prep", class: "uppercase mb16 face-on-hover footer-link" %>
+            <%= link_to "SAT & ACT", root_url(subdomain: nil) + "sat-act-prep", class: "uppercase mb16 face-on-hover" %>
           </li>
           <li>
-            <%= link_to "About", root_url(subdomain: nil) + "about_us", class: "uppercase mb16 face-on-hover footer-link" %>
+            <%= link_to "About", root_url(subdomain: nil) + "about_us", class: "uppercase mb16 face-on-hover" %>
           </li>
           <li>
-            <%= link_to "Contact", root_url(subdomain: nil) + "contact", class: "uppercase mb16 face-on-hover footer-link last" %>
+            <%= link_to "Contact", root_url(subdomain: nil) + "contact", class: "uppercase mb16 face-on-hover last" %>
           </li>
         </ul>
       </span>


### PR DESCRIPTION
The nav bar was getting really long and causing style issues on production. This PR shortens the nav bar by removing the SAT & ACT link. The page still exists thoughout the website. 

![image](https://user-images.githubusercontent.com/24426214/38883337-7330b478-4221-11e8-8695-8784a7313fd9.png)
