### PR TITLE
Adds session date data to invoices

### DIFF
--- a/db/migrate/20180502172819_update_session_dates_for_invoices.rb
+++ b/db/migrate/20180502172819_update_session_dates_for_invoices.rb
@@ -1,0 +1,13 @@
+class UpdateSessionDatesForInvoices < ActiveRecord::Migration[5.1]
+  def change
+    Invoice.find_each do |invoice|
+      next unless invoice.by_tutor? && invoice.session_date.nil?
+      invoice.session_date = invoice.created_at
+      if invoice.save
+        STDOUT.puts "Updated invoice ##{invoice.id}'s session_date to #{invoice.session_date}."
+      else
+        STDOUT.puts "Unable to update session date for invoice ##{invoice.id}."
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180426000008) do
+ActiveRecord::Schema.define(version: 20180502172819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Old invoices were not updated to have session dates which is making invoices invalid. This pr updates old invoices through migration so that all invoices have session dates.