### PR TITLE
Updates metadata for blog

### DIFF
--- a/app/views/pages/blog_posts/show.html.erb
+++ b/app/views/pages/blog_posts/show.html.erb
@@ -3,7 +3,8 @@
   <meta property="og:type"          content="website" />
   <meta property="og:title"         content="<%= @post.title %>" />
   <meta property="og:description"   content="<%= @post.excerpt %>" />
-  <meta property="og:image"         content="<%= image_url("topTutoringFinal.png") %>" />
+  <meta property="og:image"         content="" />
+  <meta property="og:image:alt"     content="<%= @post.title %>" />
 <% end %>
 
 <%= render layout: "pages/blog_posts/blog_layout" do %>


### PR DESCRIPTION
[Trello](https://trello.com/c/wULfQjJV/316-update-meta-image-for-sharing)
The Open Graph meta data on our blogs wasn't compatible with facebook.
Therefore, additional information was provided as well as the image url
removed so that there is a higher probability of the correct image being
loaded.