### PR TITLE
Adds email/phone to user modal

### DIFF
--- a/app/views/admin/users/_user_modal.html.erb
+++ b/app/views/admin/users/_user_modal.html.erb
@@ -8,10 +8,10 @@
         <div class="row mb-10">
           <div class="col-xs-4">User Id</div><div class="col-xs-8"><%= user.id %></div>
         </div>
-        <div class="row visible-xs mb-10">
+        <div class="row mb-10">
           <div class="col-xs-4">User Email</div><div class="col-xs-8"><%= user.email %></div>
         </div>
-        <div class="row visible-xs mb-10">
+        <div class="row mb-10">
           <div class="col-xs-4">User Phone Number</div><div class="col-xs-8"><%= phone_number_display(user) %></div>
         </div>
         <div class="row mb-10">


### PR DESCRIPTION
[Trello](https://trello.com/c/DBMeGcvj/291-clicking-on-name-in-users-should-show-phone-and-email)

Currently, the admin view only shows the phone number and email in the user view modal when viewed from a small device. Have it displayed always.