### PR TITLE
Limit characters for comment on contact form

### DIFF
--- a/app/views/www/pages/_contact_form.html.erb
+++ b/app/views/www/pages/_contact_form.html.erb
@@ -1,5 +1,4 @@
 <%= form_with model: Lead, url: leads_path, id: "contact-form" do |f| %>
-
   <div class="col-sm-6">
     <%= f.text_field :first_name, type: "text", placeholder: "First Name", required: true %>
   </div>
@@ -26,7 +25,7 @@
   </div>
 
   <div class="col-xs-12">
-    <%= f.text_area :comments, placeholder: "Comments", rows: "3" %>
+    <%= f.text_area :comments, placeholder: "Comments", rows: "3", maxLength: 150 %>
   </div>
 
   <div class="col-xs-12">


### PR DESCRIPTION
Solicitations generally go over 150 characters while genuine comments
are usually under. By setting a limit on the amount of characters, we
can declutter our leads from unwanted submissions.